### PR TITLE
Replace Facebook icon with Twitter icon

### DIFF
--- a/app/templates/index.twig
+++ b/app/templates/index.twig
@@ -26,7 +26,7 @@
     <div class="container">
         <div class="center-block social-footer">
             <a href="http://piwik.org" class="btn btn-xs btn-piwik">Piwik.org</a>
-            <a href="https://twitter.com/piwik" target="_blank" class="btn btn-xs btn-twitter"><i class="fa fa-facebook"></i> | Twitter</a>
+            <a href="https://twitter.com/piwik" target="_blank" class="btn btn-xs btn-twitter"><i class="fa fa-twitter"></i> | Twitter</a>
             <a href="https://github.com/piwik" target="_blank" class="btn btn-xs btn-github"><i class="fa fa-github"></i> | GitHub</a>
         </div>
     </div>


### PR DESCRIPTION
This PR switches out the Font Awesome Facebook icon for the Twitter icon in the social-footer.  I did not render the page in the browser, since I am not up and running on PHP and Slim.
