### PR TITLE
Changed 'install' function name to 'uninstall'

### DIFF
--- a/docs/persistence-and-the-mysql-backend.md
+++ b/docs/persistence-and-the-mysql-backend.md
@@ -400,7 +400,7 @@ Plugins should also clean up after themselves by dropping the tables in the [uni
     {
         // ...
 
-        public function install()
+        public function uninstall()
         {
             Db::dropTables(Common::prefixTable('mynewtable'));
         }


### PR DESCRIPTION
The example of an plugin's unsinstall function showed a function called 'install' instead of 'uninstall'.
