### PR TITLE
Specify that requests should use GET

### DIFF
--- a/docs/tracking-api.md
+++ b/docs/tracking-api.md
@@ -1,6 +1,6 @@
 ## The Tracking HTTP API
 
-To track page views, events, visits, you have to send a HTTP request to your Tracking HTTP API endpoint, for example, **http://your-piwik-domain.tld/piwik.php** with the correct query parameters set.
+To track page views, events, visits, you have to send a HTTP GET request to your Tracking HTTP API endpoint, for example, **http://your-piwik-domain.tld/piwik.php** with the correct query parameters set.
 
 ### Supported Query Parameters
 


### PR DESCRIPTION
I did not find this information until I checked the source code of the PHP client. I think it should be specified clearly in the documentation.
