### PR TITLE
Improved develop page for plugin developers

### DIFF
--- a/app/helpers/Content/Category/CategoryList.php
+++ b/app/helpers/Content/Category/CategoryList.php
@@ -13,6 +13,8 @@ class CategoryList
         switch ($name) {
             case 'Integrate':
                 return new IntegrateCategory();
+            case 'CoreDevelop':
+                return new CoreDevelopCategory();
             case 'Develop':
                 return new DevelopCategory();
             case 'Design':

--- a/app/helpers/Content/Category/CoreDevelopCategory.php
+++ b/app/helpers/Content/Category/CoreDevelopCategory.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Piwik - Open source web analytics
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace helpers\Content\Category;
+
+use helpers\Content\EmptySubCategory;
+use helpers\Content\Guide;
+use helpers\Content\InternalLink;
+use helpers\Content\RemoteLink;
+
+class CoreDevelopCategory extends Category
+{
+    public function getName()
+    {
+        return 'Core Development';
+    }
+
+    public function getItems()
+    {
+        return [
+            new Guide('core-develop-introduction'),
+            new EmptySubCategory('Understanding Piwik', [
+                new Guide('how-piwik-works'),
+                new Guide('http-request-handling'),
+                new Guide('piwiks-extensibility-points'),
+            ]),
+            new EmptySubCategory('Web Interface', [
+                new Guide('controllers'),
+                new Guide('views'),
+            ]),
+            new EmptySubCategory('Reporting API', [
+                new Guide('apis'),
+                new Guide('piwiks-reporting-api'),
+            ]),
+            new Guide('data-model'),
+            new Guide('themable-plugins'),
+            new Guide('tests-travis-extended'),
+            new EmptySubCategory('Piwik Core development', [
+                new Guide('contributing-to-piwik-core'),
+                new Guide('core-team-workflow'),
+                new RemoteLink('Piwik\'s Roadmap', 'http://piwik.org/roadmap/'),
+            ]),
+            new InternalLink('Plugin development', '/develop'),
+        ];
+    }
+
+    public function getUrl()
+    {
+        return '/core';
+    }
+
+    public function getIntroGuide()
+    {
+        return new Guide('core-develop-introduction');
+    }
+}

--- a/app/helpers/Content/Category/DevelopCategory.php
+++ b/app/helpers/Content/Category/DevelopCategory.php
@@ -10,6 +10,7 @@ namespace helpers\Content\Category;
 
 use helpers\Content\EmptySubCategory;
 use helpers\Content\Guide;
+use helpers\Content\InternalLink;
 use helpers\Content\RemoteLink;
 use helpers\Content\SubCategory;
 
@@ -24,53 +25,37 @@ class DevelopCategory extends Category
     {
         return [
             new Guide('develop-introduction'),
-            new EmptySubCategory('Getting Started With Plugins', [
+            new EmptySubCategory('Getting Started', [
                 new Guide('getting-started-part-1'),
-                new Guide('getting-started-part-2'),
-                new Guide('getting-started-part-3'),
                 new Guide('distributing-your-plugin'),
             ]),
-            new EmptySubCategory('Understanding Piwik', [
-                new Guide('how-piwik-works'),
-                new Guide('http-request-handling'),
-                new Guide('piwiks-extensibility-points'),
-            ]),
-            new EmptySubCategory('Web Interface', [
-                new Guide('controllers'),
-                new Guide('views'),
+            new EmptySubCategory('Plugin Basics', [
+                new Guide('custom-reports'),
+                new Guide('visualizing-report-data'),
+                new Guide('theming'),
                 new Guide('pages'),
                 new Guide('menus'),
                 new Guide('widgets'),
                 new Guide('working-with-piwiks-ui'),
-                new Guide('visualizing-report-data'),
-            ]),
-            new EmptySubCategory('Reporting API', [
-                new Guide('apis'),
-                new Guide('piwiks-reporting-api'),
-            ]),
-            new Guide('piwik-on-the-command-line'),
-            new Guide('data-model'),
-            new EmptySubCategory('Database', [
-                new Guide('persistence-and-the-mysql-backend'),
-                new Guide('extending-database'),
-            ]),
-            new Guide('piwik-configuration'),
-            new EmptySubCategory('Security', [
-                new Guide('security-in-piwik'),
-                new Guide('permissions'),
+                new Guide('plugin-settings'),
+                new Guide('piwiks-ini-configuration'),
+                new Guide('scheduled-tasks'),
+                new Guide('piwik-on-the-command-line'),
             ]),
             new SubCategory(new Guide('internationalization'), [
                 new RemoteLink('Make your plugin multilingual', 'http://piwik.org/blog/2014/10/how-to-make-your-plugin-multilingual-introducing-the-piwik-platform/'),
             ]),
             new Guide('tests'),
-            new Guide('logging'),
-            new Guide('scheduled-tasks'),
-            new EmptySubCategory('Piwik Core development', [
-                new Guide('contributing-to-piwik-core'),
-                new Guide('core-team-workflow'),
-                new RemoteLink('Piwik\'s Roadmap', 'http://piwik.org/roadmap/'),
+            new EmptySubCategory('Security', [
+                new Guide('security-in-piwik'),
+                new Guide('permissions'),
             ]),
-            new Guide('design-introduction'),
+            new EmptySubCategory('Database', [
+                new Guide('persistence-and-the-mysql-backend'),
+                new Guide('extending-database'),
+            ]),
+            new Guide('logging'),
+            new InternalLink('Core development', '/core'),
         ];
     }
 

--- a/app/helpers/Content/InternalLink.php
+++ b/app/helpers/Content/InternalLink.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace helpers\Content;
+
+/**
+ * Link on an internal URL (e.g. the blog).
+ */
+class InternalLink implements MenuItem
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $url;
+
+    public function __construct($name, $url)
+    {
+        $this->name = $name;
+        $this->url = $url;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMenuTitle()
+    {
+        return '<i class=""></i> ' . $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMenuUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * @return MenuItem[]
+     */
+    public function getSubItems()
+    {
+        return [];
+    }
+}

--- a/app/helpers/Redirects.php
+++ b/app/helpers/Redirects.php
@@ -26,6 +26,7 @@ class Redirects
             '/guides/mvc-controllers'          => '/guides/controllers',
             '/guides/all-about-analytics-data' => '/guides/data-model',
             '/guides/all-about-tracking'       => '/guides/tracking-introduction',
+            '/guides/getting-started-part-2'   => '/guides/report',
         ];
     }
 }

--- a/app/helpers/SearchIndex.php
+++ b/app/helpers/SearchIndex.php
@@ -4,6 +4,7 @@ namespace helpers;
 
 use helpers\Content\Category\ApiReferenceCategory;
 use helpers\Content\Category\Category;
+use helpers\Content\Category\CoreDevelopCategory;
 use helpers\Content\Category\DesignCategory;
 use helpers\Content\Category\DevelopCategory;
 use helpers\Content\Category\IntegrateCategory;
@@ -28,6 +29,7 @@ class SearchIndex
             new DevelopCategory(),
             new DesignCategory(),
             new ApiReferenceCategory(),
+            new CoreDevelopCategory()
         ];
 
         $items = [];

--- a/app/routes/page.php
+++ b/app/routes/page.php
@@ -12,6 +12,7 @@ use helpers\Content\Category\CategoryList;
 use helpers\Content\Category\ChangelogCategory;
 use helpers\Content\Category\DesignCategory;
 use helpers\Content\Category\DevelopCategory;
+use helpers\Content\Category\CoreDevelopCategory;
 use helpers\Content\Guide;
 use helpers\Content\PhpDoc;
 use helpers\Content\Category\IntegrateCategory;
@@ -83,6 +84,11 @@ $app->get('/design', function () use ($app) {
 
 $app->get('/develop', function () use ($app) {
     $category = new DevelopCategory();
+    renderGuide($app, $category->getIntroGuide(), $category);
+});
+
+$app->get('/core', function () use ($app) {
+    $category = new CoreDevelopCategory();
     renderGuide($app, $category->getIntroGuide(), $category);
 });
 

--- a/docs/apis.md
+++ b/docs/apis.md
@@ -1,5 +1,5 @@
 ---
-category: Develop
+category: CoreDevelop
 ---
 # Piwik APIs
 

--- a/docs/archive-data.md
+++ b/docs/archive-data.md
@@ -1,5 +1,5 @@
 ---
-category: Develop
+category: CoreDevelop
 previous: archiving
 next: reports
 ---

--- a/docs/archiving.md
+++ b/docs/archiving.md
@@ -1,5 +1,5 @@
 ---
-category: Develop
+category: CoreDevelop
 previous: log-data
 next: archive-data
 ---

--- a/docs/contributing-to-piwik-core.md
+++ b/docs/contributing-to-piwik-core.md
@@ -1,5 +1,5 @@
 ---
-category: Develop
+category: CoreDevelop
 ---
 # Contributing to Piwik Core
 

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -1,5 +1,5 @@
 ---
-category: Develop
+category: CoreDevelop
 ---
 # Controllers
 

--- a/docs/core-develop-introduction.md
+++ b/docs/core-develop-introduction.md
@@ -1,0 +1,18 @@
+---
+category: CoreDevelop
+title: Introduction
+---
+# Core Development
+
+Welcome to the *Core Development* section of the Piwik Developer Zone. 
+If you are interested in contributing to the Piwik core or if you want to get more insight into Piwik, you are at the right place!
+
+This section contains guides that will help you to:
+
+- understand **how Piwik works in depth**
+- **contribute** to Piwik itself to fix bugs or add new features
+
+Use the sidebar to navigate through the guides. Here is a list of guides to get you started:
+
+- [How Piwik Works](/guides/how-piwik-works)
+- [Contributing to Piwik Core](/guides/contributing-to-piwik-core)

--- a/docs/core-team-workflow.md
+++ b/docs/core-team-workflow.md
@@ -1,5 +1,5 @@
 ---
-category: Develop
+category: CoreDevelop
 ---
 # The Core Team Workflow
 

--- a/docs/custom-reports.md
+++ b/docs/custom-reports.md
@@ -1,32 +1,16 @@
 ---
 category: Develop
-previous: getting-started-part-1
-next: getting-started-part-3
 ---
-# Getting Started Part II: Tour of Piwik Internals
+# Custom Report
 
-## About this guide
-
-In [Part I](/guides/getting-started-part-1) you set up your development environment and created a new plugin. In this guide, we'll make that plugin do something and in the process, you'll learn about different Piwik concepts.
+In our [Setting up](/guides/getting-started-part-1) guide you set up your development environment and created a new plugin. In this guide, we'll make that plugin do something and in the process, you'll learn about different Piwik concepts.
 
 This guide will show you:
 
-- **how to define controllers to add new pages to Piwik**
 - **how to define new reports and expose them through Piwik's [Reporting API](/api-reference/reporting-api)**
 - **how to use JavaScript in a plugin**
 
-**Guide Assumptions**
-
-This guide assumes that you've completed [Part I](/guides/getting-started-part-1) of this guide.
-
-## Make your plugin do something
-
-For the sake of this guide we don't want to do anything complicated. We will:
-
-- define a new analytics report that uses raw log data
-- add a new page to Piwik that displays the report
-
-### Adding a new report
+## Adding a new report
 
 We're going to create a new report that shows the browsers used for the most recent visits. We'll be using data returned by the [Live!](http://piwik.org/docs/real-time/#the-real-time-live-widget) plugin so we won't have to do much processing ourselves.
 
@@ -47,7 +31,7 @@ To add a new report you should use the CLI tool and execute the following comman
 
 This command will guide you through the creation of a report and ask for several things such as the name of your plugin and the name of the report you want to create. When it asks you for a report name, enter "Last Visits By Browser", choose the category "Visitors" by moving the arrow keys up or down and leave the dimension empty.
 
-#### Adding a menu item
+### Adding a menu item
 
 The CLI tool has created a new file `Reports/GetLastVisitsByBrowser.php` within your plugin folder. We recommend to take the time to have a look at all the methods and comments to get an idea how a report is defined.
 
@@ -69,7 +53,7 @@ If you click on it, the page will be loaded below the period selector:
 
 <img src="/img/myplugin_index_embed.png"/>
 
-#### Making it a widget
+### Making it a widget
 
 A widget allows users to add your report to the dashboard. It also lets them embed the report on other websites, for example using an iframe.
 
@@ -77,7 +61,7 @@ Making a widget is also very easy. Just define a property named `widgetTitle` an
 
     $this->widgetTitle = 'Real-time Reports';
 
-### Adding a API method
+## Adding a API method
 
 Reports and metrics are served by API class methods.
 
@@ -98,7 +82,7 @@ The website is determined by the `$idSite` parameter and the period by both the 
 
 You can see the output of this method if you visit this URL: [http://localhost/index.php?module=API&method=MyPlugin.getLastVisitsByBrowser&idSite=1&date=today&period=week](http://localhost/index.php?module=API&method=MyPlugin.getLastVisitsByBrowser&idSite=1&date=today&period=week).
 
-#### Implementing the API method
+### Implementing the API method
 
 Our new report will use realtime visit data. To get it, our API method will use the `Live.getLastVisitsDetails` method:
 
@@ -192,7 +176,7 @@ This new API method directly accesses visit data. That is because the report is 
 Archived reports are calculated and **cached** during the [Archiving Process](/guides/archiving). To learn more, read about Piwik's [Data Model](/guides/data-model) guide.
 </div>
 
-#### Displaying the report
+### Displaying the report
 
 Now that we've defined a new report, we need to define how the report should be displayed. We'll do this by going back to the `GetLastVisitsByBrowser` class and modify the `configureView()` method:
 
@@ -225,11 +209,11 @@ The [ViewDataTable](/api-reference/Piwik/Plugin/ViewDataTable) class outputs a *
 It is possible for plugins to create their own visualizations. To find out how, read our [Visualizing Report Data](/guides/visualizing-report-data) guide (after you're done with this guide, of course).
 </div>
 
-### Updating the report in realtime
+## Updating the report in realtime
 
 So now there's a page with a report that displays the browsers of the latest visitors. It uses realtime data, but it's not truly realtime since after a couple minutes, the report will be out of date. To make the report more realtime we'll update the report every 10 seconds automatically.
 
-#### Adding JavaScript files to Piwik
+### Adding JavaScript files to Piwik
 
 To make the report reload itself, we'll have to write some JavaScript code. This means we'll need a JavaScript file.
 
@@ -257,7 +241,7 @@ Remember that Piwik will include this file directly only when `disable_merged_as
 
 If this option is disabled, Piwik will merge all Javascript files into one to optimize the page loading time, but that means that any change to `plugin.js` will be ignored.
 
-#### Reloading the report
+### Reloading the report
 
 In your `plugin.js` file, add the following code:
 
@@ -285,7 +269,7 @@ As you can see, all our javascript code is inside the `$(document).ready` callba
 
 Now if you open the report in your browser, you'll see the report being reloaded every 10 seconds.
 
-Well, our simple plugin is done! It defines a new report, displays it and makes sure the data it displays is fresh. But we can do better! [The next guide](/guides/getting-started-part-3) will show you how.
+Well, our simple plugin is done! It defines a new report, displays it and makes sure the data it displays is fresh. 
 
 <div markdown="1" class="alert alert-warning">
 **Security in Piwik**

--- a/docs/design-introduction.md
+++ b/docs/design-introduction.md
@@ -2,7 +2,6 @@
 category: Develop
 subGuides:
   - theming
-  - themable-plugins
 ---
 # Themes
 

--- a/docs/develop-introduction.md
+++ b/docs/develop-introduction.md
@@ -6,14 +6,11 @@ title: Introduction
 
 Welcome to the *Develop* section of the Piwik Developer Zone. If you are interested in customizing Piwik, you are at the right place!
 
-This section contains guides that will help you to:
+This section contains guides that will help you to create **Plugins** and **Themes** to customize Piwik or add new features to Piwik.
 
-- understand **how Piwik works**
-- create **Plugins** to customize or add new features
-- **contribute** to Piwik itself to fix bugs or add new features
+If you want to get more insight into how Piwik works behind the API's check out our [Core development](/core) section.
 
 Use the sidebar to navigate through the guides. Here is a list of guides to get you started:
 
-- [How Piwik Works](/guides/how-piwik-works)
-- [Getting Started with Plugins: Part I](/guides/getting-started-part-1)
-- [Contributing to Piwik Core](/guides/contributing-to-piwik-core)
+- [Getting Started: Setting up](/guides/getting-started-part-1)
+- [Distributing Your Plugin](/guides/distributing-your-plugin)

--- a/docs/getting-started-part-1.md
+++ b/docs/getting-started-part-1.md
@@ -1,8 +1,7 @@
 ---
 category: Develop
-next: getting-started-part-2
 ---
-# Getting Started Part I: Setting Up
+# Setting Up
 
 <!-- Meta (to be deleted)
 TODO: (stuff that needs to go in SOME guide)
@@ -164,13 +163,9 @@ The command-line tool will create a new directory for your plugin (in the **plug
 
 Ok! You've set up your development environment and created your plugin! Now all you have to do is make it do what you want. The bad news is that this is the hard part. The good news is that we've written a bunch of other guides to help you shorten the learning curve.
 
-If you'd like to learn the basics of Piwik plugin development all at once, continue on to the [next part in this series of guides](/guides/getting-started-part-2). If you want to learn how to do just one thing, try reading one of our other guides:
-
-- If you're interested in **creating new analytics reports**, you may want to read about [Reports](/guides/reports) and [Visualizing Report Data](/guides/visualizing-report-data) guides.
+- If you're interested in **creating new analytics reports**, you may want to read about [Custom Reports](/guides/custom-reports) and [Visualizing Report Data](/guides/visualizing-report-data) guides.
 - If you're interested in **changing the look and feel of Piwik**, read our [Theming](/guides/theming) guide.
-- If you're interested in **taking part in core development**, read our [Contributing to Piwik Core](/guides/contributing-to-piwik-core) guide.
 - If you're interested in **integrating Piwik with another technology**, you might want to read our [Tracking guides](/guides/tracking-introduction) to learn how to use our Tracking API.
-- If you'd like to **add new console commands**, read our [Piwik on the command line](/guides/piwik-on-the-command-line) guide.
 - If you want to **use automated testing to ensure your plugin works**, read your [Automated Tests](/guides/tests) guide.
 
 And **make sure to read our security guide, [Security in Piwik](/guides/security-in-piwik)**! We have very high security standards that your plugin or contribution **must** respect.

--- a/docs/getting-started-part-3.md
+++ b/docs/getting-started-part-3.md
@@ -1,6 +1,5 @@
 ---
 category: Develop
-previous: getting-started-part-2
 ---
 # Getting Started Part III: Extras
 

--- a/docs/how-piwik-works.md
+++ b/docs/how-piwik-works.md
@@ -1,5 +1,5 @@
 ---
-category: Develop
+category: CoreDevelop
 ---
 # How Piwik Works
 

--- a/docs/http-request-handling.md
+++ b/docs/http-request-handling.md
@@ -1,5 +1,5 @@
 ---
-category: Develop
+category: CoreDevelop
 ---
 # How Piwik Handles HTTP Requests
 

--- a/docs/log-data.md
+++ b/docs/log-data.md
@@ -1,5 +1,5 @@
 ---
-category: Develop
+category: CoreDevelop
 previous: data-model
 next: archiving
 ---

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,7 +1,7 @@
 ---
 category: Develop
 ---
-# Permissions
+# User permissions
 
 Permissions define what a user can see or do in Piwik.
 

--- a/docs/piwik-configuration.md
+++ b/docs/piwik-configuration.md
@@ -1,8 +1,8 @@
 ---
 category: Develop
 subGuides:
-  - piwiks-ini-configuration
   - plugin-settings
+  - piwiks-ini-configuration
 ---
 # Configuration
 

--- a/docs/piwik-on-the-command-line.md
+++ b/docs/piwik-on-the-command-line.md
@@ -1,7 +1,7 @@
 ---
 category: Develop
 ---
-# Command Line Interface
+# Commands
 
 As explained in the [*How Piwik Works* guide](http://developer.piwik.org/guides/how-piwik-works#interfaces), Piwik can be used through several interfaces, the command line being one of them.
 

--- a/docs/piwiks-extensibility-points.md
+++ b/docs/piwiks-extensibility-points.md
@@ -1,5 +1,5 @@
 ---
-category: Develop
+category: CoreDevelop
 ---
 # Piwik's Extensibility Points
 

--- a/docs/piwiks-ini-configuration.md
+++ b/docs/piwiks-ini-configuration.md
@@ -2,6 +2,7 @@
 category: Develop
 previous: piwik-configuration
 next: plugin-settings
+title: Configuration
 ---
 # INI Configuration
 

--- a/docs/piwiks-reporting-api.md
+++ b/docs/piwiks-reporting-api.md
@@ -1,5 +1,5 @@
 ---
-category: Develop
+category: CoreDevelop
 ---
 # Reporting HTTP API
 

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -1,5 +1,5 @@
 ---
-category: Develop
+category: CoreDevelop
 previous: archive-data
 ---
 # Reports

--- a/docs/tests-travis-extended.md
+++ b/docs/tests-travis-extended.md
@@ -1,0 +1,73 @@
+---
+category: Develop
+previous: tests-ui
+---
+# Travis CI: Extended
+
+### Auto-updating the .travis.yml file
+
+The `generate:travis-yml` command will be changed over time as we modify the travis build process. To avoid having to 
+update the travis file manually you can setup auto-updating by using the `--github-token=` option when calling `generate:travis-yml`. You should supply a [GitHub token](https://help.github.com/articles/creating-an-access-token-for-command-line-use) that has read and write access to the repository the build is for. When a .travis.yml file is found to be out of date, the Travis build will update the file and push a commit using the GitHub token.
+
+*Note: you will need the [travis command line tool](http://blog.travis-ci.com/2013-01-14-new-client/) to setup auto-updating.*
+
+### Varying .travis.yml behavior
+
+You can control how the generated .travis.yml file behaves, by setting certain environment variables in your .travis.yml file.
+
+These variables let you download other, test your plugin against a specific Piwik version and more.
+
+Below is the list of all supported environment variables:
+
+  * **TRAVIS\_COMMITTER\_NAME**
+  * **TRAVIS\_COMMITTER\_EMAIL**
+
+    These variables control the username and email address used when commiting changes from within a travis build.
+
+    When the .travis.yml file is auto-updated, the travis build will commit the changes and push them to your plugin's git repository. The committer's username and email address are determined by these variable.
+
+    `TRAVIS_COMMITTER_NAME` defaults to `Piwik Automation`. `TRAVIS_COMMITTER_EMAIL` defaults to `hello@piwik.org`.
+
+    Example usage:
+
+    ```
+    env:
+      global:
+        - TRAVIS_COMMITTER_NAME="My Org Automation"
+        - TRAVIS_COMMITTER_EMAIL=my-org@myorg.com
+    ```
+
+  * **UNPROTECTED\_ARTIFACTS**
+
+    **For core or pro developers only.** This variable controls whether build artifacts will be uploaded to a password protected folder on builds-artifacts.piwik.org or not.
+
+    By default, artifacts for plugins are stored in a protected folder. To change this behavior, set `UNPROTECTED_ARTIFACTS=1` as a global environment variable, eg:
+
+    ```
+    env:
+      global:
+        - UNPROTECTED_ARTIFACTS=1
+    ```
+
+### Extending .travis.yml behavior
+
+Plugins that use technologies other than MySQL or PHP may require extra setup and install steps to be executed on travis before running tests.
+
+[LoginLdap](https://github.com/piwik/plugin-LoginLdap), for example, tests itself against a live LDAP server and thus needs to install and setup OpenLDAP on travis. To accomplish this, [LoginLdap](https://github.com/piwik/plugin-LoginLdap) adds extra steps to its generated .travis.yml file.
+
+To add extra steps to your plugin's .travis.yml file, create a `/tests/travis` folder inside your plugin and add one or more of the following special .yml files:
+
+  * before_install.before.yml
+  * before_install.after.yml
+  * install.before.yml
+  * install.after.yml
+  * before_script.before.yml
+  * before_script.after.yml
+  * after_script.before.yml
+  * after_script.after.yml
+  * after_success.before.yml
+  * after_success.after.yml
+
+The contents of the `XXX.before.yml` files will be prepended to the specific section in your .travis.yml file, while the contents of the `XXX.after.yml` files will be appended.
+
+*Note: You cannot simply add these changes by hand to the .travis.yml file since they will be overwritten on the next `generate:travis-yml` execution.*

--- a/docs/tests-travis.md
+++ b/docs/tests-travis.md
@@ -8,11 +8,9 @@ previous: tests-ui
 
 ## Piwik's tests on Travis CI
 
-Piwik uses Travis to automatically run its test suite on every commit (for every branch and pull request):
+Piwik uses Travis to automatically run its test suite on every commit (for every branch and pull request). PHP and UI tests are run on the [piwik/piwik](https://travis-ci.org/piwik/piwik/builds) build
 
-- PHP and UI tests are run on the [piwik/piwik](https://travis-ci.org/piwik/piwik/builds) build
-
-  Current status for master branch: [![Build Status](https://travis-ci.org/piwik/piwik.svg?branch=master)](https://travis-ci.org/piwik/piwik)
+Current status for master branch: [![Build Status](https://travis-ci.org/piwik/piwik.svg?branch=master)](https://travis-ci.org/piwik/piwik)
 
 ## Running your plugins tests on Travis CI
 
@@ -24,17 +22,9 @@ $ ./console generate:travis-yml --plugin=MyPlugin
 
 The command will automatically detect if you have PHP and/or UI tests in your plugin's `Test/` directory and create a `.travis.yml` file that will run them. The tests will be run against both Piwik `master` branch and against the latest stable version.
 
-**Modifying the .travis.yml file**
-
-The `generate:travis-yml` command will not overwrite the `env:` and `matrix:` sections of an existing .travis.yml file. This means your modifications will be preserved when the file is updated.
-
-### Auto-updating the .travis.yml file
+### Updating the .travis.yml file
 
 The `generate:travis-yml` command will be changed over time as we modify the travis build process. The generated `.travis.yml` file will check if it is out of date from within travis and let you know by failing the build. In such a case you will have to re-run the command and commit the changes to get the build to run again.
-
-To avoid having to do this you can setup auto-updating by using the `--github-token=` option when calling `generate:travis-yml`. You should supply a [GitHub token](https://help.github.com/articles/creating-an-access-token-for-command-line-use) that has read and write access to the repository the build is for. When a .travis.yml file is found to be out of date, the Travis build will update the file and push a commit using the GitHub token.
-
-*Note: you will need the [travis command line tool](http://blog.travis-ci.com/2013-01-14-new-client/) to setup auto-updating.*
 
 ### Varying .travis.yml behavior
 
@@ -82,36 +72,6 @@ Below is the list of all supported environment variables:
         - DEPENDENT_PLUGINS="myGithubAccount/myDependentPlugin myGithubAccount/myOtherDependentPlugin"
     ```
 
-  * **TRAVIS\_COMMITTER\_NAME**
-  * **TRAVIS\_COMMITTER\_EMAIL**
-
-    These variables control the username and email address used when commiting changes from within a travis build.
-
-    When the .travis.yml file is auto-updated, the travis build will commit the changes and push them to your plugin's git repository. The committer's username and email address are determined by these variable.
-
-    `TRAVIS_COMMITTER_NAME` defaults to `Piwik Automation`. `TRAVIS_COMMITTER_EMAIL` defaults to `hello@piwik.org`.
-
-    Example usage:
-
-    ```
-    env:
-      global:
-        - TRAVIS_COMMITTER_NAME="My Org Automation"
-        - TRAVIS_COMMITTER_EMAIL=my-org@myorg.com
-    ```
-
-  * **UNPROTECTED\_ARTIFACTS**
-
-    **For core or pro developers only.** This variable controls whether build artifacts will be uploaded to a password protected folder on builds-artifacts.piwik.org or not.
-
-    By default, artifacts for plugins are stored in a protected folder. To change this behavior, set `UNPROTECTED_ARTIFACTS=1` as a global environment variable, eg:
-
-    ```
-    env:
-      global:
-        - UNPROTECTED_ARTIFACTS=1
-    ```
-
 ### Extending .travis.yml behavior
 
 Plugins that use technologies other than MySQL or PHP may require extra setup and install steps to be executed on travis before running tests.
@@ -132,5 +92,3 @@ To add extra steps to your plugin's .travis.yml file, create a `/tests/travis` f
   * after_success.after.yml
 
 The contents of the `XXX.before.yml` files will be prepended to the specific section in your .travis.yml file, while the contents of the `XXX.after.yml` files will be appended.
-
-*Note: You cannot simply add these changes by hand to the .travis.yml file since they will be overwritten on the next `generate:travis-yml` execution.*

--- a/docs/themable-plugins.md
+++ b/docs/themable-plugins.md
@@ -1,5 +1,5 @@
 ---
-category: Develop
+category: CoreDevelop
 ---
 # Writing themable plugins
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,5 +1,6 @@
 ---
 category: Develop
+title: Theming
 ---
 # Writing a theme
 

--- a/docs/views.md
+++ b/docs/views.md
@@ -1,5 +1,5 @@
 ---
-category: Develop
+category: CoreDevelop
 ---
 # Views
 

--- a/docs/visualizing-report-data.md
+++ b/docs/visualizing-report-data.md
@@ -1,7 +1,7 @@
 ---
 category: Develop
 ---
-# Displaying Reports
+# Report visualizations
 
 In Piwik, an **analytics report** is just a set of two-dimensional data, stored as [DataTable](/api-reference/Piwik/DataTable) objects and returned by API methods.
 


### PR DESCRIPTION
I removed many links from the develop menu that are only important
for core developers or pro developers to a section named Core development
which can be reached from the develop menu (very bottom of the menu) or
from the develop-introduction page. We could maybe also name it
"Piwik in depth" or similar instead of "Core development" in case someone
is interested in those details.

I splitted some pages already in 2, eg tests-travis for plugin developers
and tests-travis for core.

Getting started is now only one page. The second part is now under Plugin
basics as "Custom Report". The third getting started page is completely
removed as it is explained in the other guides anyway.

The menu contained many links before that are not important for the majority
as we are only a few core developers and some of us do not even really use
developer.piwik.org as we are aware of this stuff. It should be still reachable.
That's why there are links to the core section and some guides might link to
the extended guides in core directly.