### PR TITLE
Shorten the introduction of some guides

### DIFF
--- a/docs/piwik-on-the-command-line.md
+++ b/docs/piwik-on-the-command-line.md
@@ -3,7 +3,7 @@ category: Develop
 ---
 # Commands
 
-As explained in the [*How Piwik Works* guide](http://developer.piwik.org/guides/how-piwik-works#interfaces), Piwik can be used through several interfaces, the command line being one of them.
+Piwik can be used through several interfaces, the command line being one of them.
 
 The CLI console lets user run **commands** defined by plugins. Those commands can be used to perform maintenance, to monitor the application, to ease development…
 

--- a/docs/security-in-piwik.md
+++ b/docs/security-in-piwik.md
@@ -3,21 +3,6 @@ category: Develop
 ---
 # Security best practices
 
-## About this guide
-
-**Read this guide if**
-
-* you'd like to know **how to write secure code when extending Piwik or contributing to Piwik**
-
-**Guide assumptions**
-
-This guide assumes that you:
-
-* can code in PHP, JavaScript and SQL,
-* and have a general understanding of extending Piwik (if not, read our [Getting Started](/guides/getting-started-part-1) guide).
-
-## Introduction
-
 If you plan on developing a plugin or [contributing to Piwik Core](/guides/contributing-to-piwik-core) **your code must be secure**.
 
 This guide contains a list of methods to combat certain vulnerabilities. Follow all of them when working on your plugin or contribution.

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -20,20 +20,10 @@ What's missing? (stuff in my list that was not in when I wrote the 1st draft)
 - plugin developers + otrance
 -->
 
-## About this guide
+Read this guide if you'd like to know
 
-**Read this guide if**
-
-* you'd like to know **how to make your plugin available in other languages**
-* you'd like to know **how to make your contribution to Piwik Core available in other languages**
-
-**Guide assumptions**
-
-This guide assumes that you:
-
-* can code in PHP, JavaScript or can create Twig templates,
-* know what [internationalization](http://en.wikipedia.org/wiki/Internationalization_and_localization) is,
-* and that you have generated a plugin (if not, read our [Setting up Piwik](/guides/getting-started-part-1) guide).
+* **how to make your plugin available in other languages**
+* **how to make your contribution to Piwik Core available in other languages**
 
 ## The Basics
 

--- a/docs/working-with-piwiks-ui.md
+++ b/docs/working-with-piwiks-ui.md
@@ -3,20 +3,11 @@ category: Develop
 ---
 # JavaScript and CSS
 
-## About this guide
+Read this guide if you'd like to know
 
-This guide describes how plugins should create JavaScript and describes all of the JavaScript classes provided by Piwik for use by plugins.
-
-Read this guide if
-
-* you'd like to know **how to work with Piwik Core's JavaScript code**
-* you'd like to know **how to add popovers to Piwik's UI**
-
-This guide assumes that you:
-
-* know about JavaScript and [jQuery](http://jquery.com/),
-* know about CSS and [LESS](http://lesscss.org/),
-* and that you have generated a plugin (if not, read our [Setting up Piwik](/guides/getting-started-part-1) guide).
+* **how to load JavaScript and CSS files in the Piwik UI**
+* **how plugins should create JavaScript files**
+* **how to work with Piwik Core's JavaScript code**
 
 ## JavaScript libraries
 


### PR DESCRIPTION
Some guides but only a few had an `About this guide` section. I think in the beginning most guides had such a section but now only a few have it and I suggest to remove it from the remaining ones under `Develop` as well. 

Most of them always have the same content eg you need to know PHP, read the getting started guide, ...

Guides should be written in a form that they only require the Getting started guide as a precondition. If one anyone needs special knowledge during the guide we can link to it. Eg to Less or Twig.

Some mentioned requirements were even kinda wrong or not ideal. Eg Translations guide mentioned one needs to have knowledge of PHP, Twig, JavaScript, ... and then there are 3 sections about PHP, Twig, JavaScript. One actually doesn't need knowledge of Twig if one is only interested in the PHP section for example. You get the point.