### PR TITLE
Documentation for dimensions

### DIFF
--- a/app/helpers/Content/Category/DevelopCategory.php
+++ b/app/helpers/Content/Category/DevelopCategory.php
@@ -34,6 +34,7 @@ class DevelopCategory extends Category
             new EmptySubCategory('Plugin Basics', [
                 new Guide('custom-reports'),
                 new Guide('expose-api-methods'),
+                new Guide('dimensions'),
                 new Guide('theming'),
                 new Guide('pages'),
                 new Guide('menus'),

--- a/docs/dimensions.md
+++ b/docs/dimensions.md
@@ -53,7 +53,7 @@ When a new visitor is being tracked, the value `1` will be stored. On each furth
 
 ## Action dimensions
 
-Action dimensions work similar, just the method name is differently. Let's say you want to track the current speed of a runner by exposing a new URL parameter `speed`:
+Action dimensions work similarly, just the method name is different. Let's say you want to track the current speed of a runner by exposing a new URL parameter `speed`:
 
 ```php
 public function onNewAction(Request $request, Visitor $visitor, Action $action)
@@ -80,4 +80,4 @@ Of course you can add any custom behaviour like limiting the max speed etc.
 A new segment is automatically created for a dimension and defined in the method `configureSegments`. All you usually have to do is to adjust the description of the accepted values.
 
 ## Learn more
-Dimensions are quite powerful. For example you can change the behavior of an existing dimension by creating a dimension that has the same column name, you can store action related data very space efficient by using a lookup table and they can force the creation of a new visit in case an existing visitor was recognized. We recommend to have a look at the documentation within a created dimension and at the API-Reference of the classes [VisitDimension](/api-reference/Piwik/Plugin/Dimension/VisitDimension), [ActionDimension](/api-reference/Piwik/Plugin/Dimension/ActionDimension) and [ConversionDimension](/api-reference/Piwik/Plugin/Dimension/ConversionDimension)
+Dimensions are quite powerful. For example you can change the behavior of an existing dimension by creating a dimension that has the same column name, you can store action related data efficiently by using a lookup table. Dimensions can also force the creation of a new visit in case an existing visitor was recognized. We recommend to have a look at the documentation within a created dimension and at the API-Reference of the classes [VisitDimension](/api-reference/Piwik/Plugin/Dimension/VisitDimension), [ActionDimension](/api-reference/Piwik/Plugin/Dimension/ActionDimension) and [ConversionDimension](/api-reference/Piwik/Plugin/Dimension/ConversionDimension)

--- a/docs/dimensions.md
+++ b/docs/dimensions.md
@@ -1,0 +1,83 @@
+---
+category: Develop
+---
+# Dimensions
+
+Dimensions provide the possibility to extend the tracker to easily record any custom data. Before recording any custom data you have to decide what kind of dimension you need:
+
+* A visit dimension let's you record any visitor related data. A typical dimension would be for example the name of the browser or the resolution of the device a visitor is using.
+* An action dimension let's you track additional data with each action. For example a pageview, a download or an event.
+* A conversion dimension let's you record any additional information when a goal is converted.
+
+## Creating a new dimension
+
+To create a new dimension, use the console:
+
+```bash
+./console generate:dimension
+```
+
+The command will ask for your plugin name and what kind of dimension you'd like to create. You can choose between `visit`, `action` and `conversion`. Next it will ask you for the name of the dimension (eg 'Browsername'), for the MySQL database column name (eg `browser_name`) and column type (eg `VARCHAR(255) NOT NULL`).
+
+Once all information is provided, a dimension class will be created in the `Columns` directory of your plugin containing an example on how to define which data should be tracked. The dimension will be automatically installed as soon as you open the Piwik UI.
+
+## Visit dimension example
+
+Let's assume you want to add a new tracking URL parameter `sport_activity_type` that let's you track the type of sport activity (eg running, cycling, ...). You can do this by implementing the method `onNewVisit`:
+
+```php
+public function onNewVisit(Request $request, Visitor $visitor, $action)
+{
+	return Common::getRequestVar('sport_activity_type', $default = false, 'string', $request->getParams());
+}
+```
+
+Whenever you send a `sport_activity_type` parameter with any tracking request and the tracker detected a new visitor, this information will be recorded in the database and can be used to create new reports or to extend existing reports and API methods. An example tracking URL could look like this `piwik.php?idsite=1&sport_activity_type=running`
+
+Optionally, you can overwrite any initial value that was written when a new visit was detected by implementing the method `onExistingVisit`. You can use this for example for counters, to store the time of the last action etc:
+
+```php
+public function onNewVisit(Request $request, Visitor $visitor, $action)
+{
+    return 1;
+}
+
+public function onExistingVisit(Request $request, Visitor $visitor, $action)
+{
+    return $visitor->getVisitorColumn($this->column_name) + 1;
+}
+```
+
+When a new visitor is being tracked, the value `1` will be stored. On each further tracking request the value for this dimension will be increased.
+
+
+## Action dimension example
+
+Action dimensions work similar, just the method name is differently. Let's say you want to track the current speed of a runner by exposing a new URL parameter `speed`:
+
+```php
+public function onNewAction(Request $request, Visitor $visitor, Action $action)
+{
+    $value = Common::getRequestVar('speed', false, 'string', $request->getParams());
+
+    $isRunner = 'running' === $visitor->getVisitorColumn('sport_activity_type');
+
+    if ($isRunner && is_numeric($value)) {
+        // only store the value if it is a runner and if speed is numeric
+        return $value;
+    }
+
+    return false; // do not store any value for this action
+}
+```
+
+A tracking request could be done like this: `piwik.php?idsite=1&sport_activity_type=running&speed=50`.
+
+Of course you can add any custom behaviour like limiting the mex speed etc.
+
+
+## Segmentation
+A new segment is automatically created for a dimension and defined in the method `configureSegments`. All you usually have to do is to adjust the description of the accepted values.
+
+## Learn more
+Dimensions are quite powerful. For example you can change the behavior of an existing dimension by creating a dimension that has the same column name, you can store action related data very space efficient by using a lookup table and they can force the creation of a new visit in case an existing visitor was recognized. We recommend to have a look at the documentation within a created dimension and at the API-Reference of the classes [VisitDimension](/api-reference/Piwik/Plugin/Dimension/VisitDimension), [ActionDimension](/api-reference/Piwik/Plugin/Dimension/ActionDimension) and [ConversionDimension](/api-reference/Piwik/Plugin/Dimension/ConversionDimension)

--- a/docs/dimensions.md
+++ b/docs/dimensions.md
@@ -6,8 +6,8 @@ category: Develop
 Dimensions provide the possibility to extend the tracker to easily record any custom data. Before recording any custom data you have to decide what kind of dimension you need:
 
 * A visit dimension let's you record any visitor related data. A typical dimension would be for example the name of the browser or the resolution of the device a visitor is using.
-* An action dimension let's you track additional data with each action. For example a pageview, a download or an event.
-* A conversion dimension let's you record any additional information when a goal is converted.
+* An action dimension let's you track any action related data. For example a pageview, a download or an event.
+* A conversion dimension let's you persist any additional information when a goal is converted.
 
 ## Creating a new dimension
 
@@ -21,7 +21,7 @@ The command will ask for your plugin name and what kind of dimension you'd like 
 
 Once all information is provided, a dimension class will be created in the `Columns` directory of your plugin containing an example on how to define which data should be tracked. The dimension will be automatically installed as soon as you open the Piwik UI.
 
-## Visit dimension example
+## Visit dimensions
 
 Let's assume you want to add a new tracking URL parameter `sport_activity_type` that let's you track the type of sport activity (eg running, cycling, ...). You can do this by implementing the method `onNewVisit`:
 
@@ -51,7 +51,7 @@ public function onExistingVisit(Request $request, Visitor $visitor, $action)
 When a new visitor is being tracked, the value `1` will be stored. On each further tracking request the value for this dimension will be increased.
 
 
-## Action dimension example
+## Action dimensions
 
 Action dimensions work similar, just the method name is differently. Let's say you want to track the current speed of a runner by exposing a new URL parameter `speed`:
 
@@ -73,7 +73,7 @@ public function onNewAction(Request $request, Visitor $visitor, Action $action)
 
 A tracking request could be done like this: `piwik.php?idsite=1&sport_activity_type=running&speed=50`.
 
-Of course you can add any custom behaviour like limiting the mex speed etc.
+Of course you can add any custom behaviour like limiting the max speed etc.
 
 
 ## Segmentation


### PR DESCRIPTION
refs piwik/piwik#7837 : Deprecate no longer needed / wanted events 

This doc will be needed once we deprecate tracker events. It's not perfect but it is better compared to the event docs that we had before. Eg it is still missing what the next step is after creating a dimension. Eg how can one create a report and archive this data afterwards but truth is it is not possible yet.

I also noticed we need to improve some things in the API. Eg we should make it simpler to get params etc but will either make those changes directly or create an issue