### PR TITLE
Sync "Getting translations for your plugin" with the blog post

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -118,20 +118,20 @@ var translatedText = _pk_translate('MyPlugin_BlogPost');
 Did you know you can contribute [translations](http://piwik.org/translations/) to Piwik? In case you want to improve an existing translation, translate a missing one or add a new language go to [Piwik Translations and sign up for an account](http://translations.piwik.org). 
 
 
-## Getting translations for your plugin ##
+## Getting translations for your plugin 
 
-As long as you are developing an open source plugin hosted on github, you may get in touch with us (translations@piwik.org) in order to get your plugin translated by the Piwik translators. 
 
-You will need an account on Transifex.com. If you used a social login on Transifex, please ensure to set a password in your account settings. That will be required for fetching new translations.
+As long as you are [developing an open source plugin](http://developer.piwik.org/develop) hosted on Github, you may get in touch with us ([translations@piwik.org](mailto:translations@piwik.org?subject=Getting my Piwik plugin translated in other languages)) in order to get your plugin translated by the Piwik translators community.
 
-### Updating source strings of your plugin ###
-While doing the initial setup for your plugin, we will import your en.json available in your githubs plugin repository and configure an autoupdate for that file.
-Source strings on Transifex will so automatically sync with your repo. Changing your en.json will automatically change the source strings within Transifex.
+You will need an account on [Transifex.com](http://transifex.com/). If you use Transifex with a social login, please ensure to set a password in your account settings. This will be required for fetching new translations into your plugin repository.
 
-### How to update/fetch your plugins translations
+## Importing your plugin’s strings in the translation platform
 
-As soon as we have set up your plugin within our Piwik project on Transifex and there are new translations available, you will be able to update your plugin translations using the piwik console. You will need a locally installed Piwik with [development mode enabled](http://developer.piwik.org/guides/getting-started-part-1#enable-development-mode) and your plugin installed.
-To update the translations go to the piwik directory on your development box and execute
+While doing the initial setup for your plugin, we will import your english translation file (`en.json`) in your Github plugin repository and we will configure an auto-update for this file. Source strings on Transifex will automatically synchronise with your plugin repository. When you change any string in your `en.json` translation file, the updated English strings will automatically be imported in Transifex.
+
+## How to fetch your plugins translations into your repository
+
+As soon as we have set up your plugin within [our Piwik project on Transifex](https://www.transifex.com/piwik/piwik/) and there are new translations available, you will be able to update your plugin translations using the Piwik console. You will need a locally installed Piwik with [development mode enabled](https://developer.piwik.org/guides/getting-started-part-1#enable-development-mode), and your plugin installed. To update the translations go to the Piwik directory on your development box and execute the following command:
 
 ```bash
 ./console translations:update -u {YourTransifexUserName} -p {YourTransifexPassword} -P {YourPluginName}


### PR DESCRIPTION
Making developer doc consistent with blog post published at: https://piwik.org/blog/2015/09/how-to-get-your-piwik-plugin-translated-in-many-languages/

cc @sgiehl
