### PR TITLE
Fix tracking code typos

### DIFF
--- a/docs/tracking-javascript-guide.md
+++ b/docs/tracking-javascript-guide.md
@@ -25,9 +25,9 @@ The tracking code looks as follows:
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {
-    var u="//{$PIWIK_URL}";
+    var u="//{$PIWIK_URL}/";
     _paq.push(['setTrackerUrl', u+'piwik.php']);
-    _paq.push(['setSiteId', {$IDSITE}]]);
+    _paq.push(['setSiteId', {$IDSITE}]);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();


### PR DESCRIPTION
Added a trailing slash to the Piwik URL (like in the previous tracking code example) and removed the extra square bracket for site id.