### PR TITLE
Seo title for docs [WIP]. Fixes #104

### DIFF
--- a/app/helpers/Content/Guide.php
+++ b/app/helpers/Content/Guide.php
@@ -158,4 +158,21 @@ class Guide implements MenuItem
 
         return file_get_contents($path);
     }
+
+    /**
+     * @return string
+     */
+    public function getSEOTitle()
+    {
+        try {
+
+            //Some guides may not have the category set
+            return $this->getTitle().': '.$this->getCategory();
+
+        } catch (\RuntimeException $e) {
+
+            return $this->getTitle();
+
+        }
+    }
 }

--- a/app/templates/guide.twig
+++ b/app/templates/guide.twig
@@ -1,4 +1,4 @@
-{% if sectionTitle is defined %}{% set title = sectionTitle %}{% endif %}
+{% set title = guide.seoTitle %}
 {% set setPageHeader = false %}
 {% extends 'base.twig' %}
 

--- a/generator/template/pages/class.twig
+++ b/generator/template/pages/class.twig
@@ -4,6 +4,7 @@
 
 {% block title %}
 {% set title = class %}
+{% set category = "API Reference" %}
 {{ parent() }}
 {% endblock %}
 


### PR DESCRIPTION
On my way out of bed I just remembered seeing this issue once and took a couple minutes to try and fix it. Works well for me except in the API reference, I'll have to modify the `Sami` class to also set a category in the generated docs so that we can have titles like `DataTable: API Reference - Piwik Analytics - Developer Doc`, so far it's now showing as `DataTable - Piwik Analytics - Developer Doc`.

There are no tests because I've never written Slim tests, so I wanted your feedback early before spending time learning how to write tests for Slim and then finding out from you that my entire approach to the solution is wrong.

ping @mattab 
