### PR TITLE
Tracking multiple domain names in the same website

### DIFF
--- a/docs/3.x/tracking-javascript-guide.md
+++ b/docs/3.x/tracking-javascript-guide.md
@@ -499,6 +499,11 @@ _paq.push(['setDomains', '*.example.com']);
 
 _paq.push(['trackPageView']);
 ```
+### Tracking multiple domain names in the same website
+
+To record users across multiple domain names in the same Piwik website, we need to setup what is called Cross Domain linking. Cross domain tracking in Piwik makes sure that when the visitor visits multiple websites and domain names, the visitor data will be stored in the same visit and that the visitor ID is reused across domain names. A typical use case where cross domain is needed is for example when an ecommerce online store is on `www.awesome-shop.com` and the ecommerce shopping cart technology is on another domain such as `secure.cart.com`.
+
+Learn about setting up cross-domain tracking in our guide: [How do I accurately measure a same visitor across multiple domain names (cross domain linking)?](https://piwik.org/faq/how-to/faq_23654/)
 
 ### Tracking subdirectories of a domain in separate websites
 

--- a/docs/3.x/tracking-javascript-guide.md
+++ b/docs/3.x/tracking-javascript-guide.md
@@ -501,7 +501,7 @@ _paq.push(['trackPageView']);
 ```
 ### Tracking multiple domain names in the same website
 
-To record users across multiple domain names in the same Piwik website, we need to setup what is called Cross Domain linking. Cross domain tracking in Piwik makes sure that when the visitor visits multiple websites and domain names, the visitor data will be stored in the same visit and that the visitor ID is reused across domain names. A typical use case where cross domain is needed is for example when an ecommerce online store is on `www.awesome-shop.com` and the ecommerce shopping cart technology is on another domain such as `secure.cart.com`.
+To record a visitor across different domain names into a single visit within one Piwik website, we need to setup what is called Cross Domain linking. Cross domain tracking in Piwik makes sure that when the visitor visits multiple websites and domain names, the visitor data will be stored in the same visit and that the visitor ID is reused across domain names. A typical use case where cross domain is needed is, for example, when an ecommerce online store is on `www.awesome-shop.com` and the ecommerce shopping cart technology is on another domain such as `secure.cart.com`.
 
 Learn about setting up cross-domain tracking in our guide: [How do I accurately measure a same visitor across multiple domain names (cross domain linking)?](https://piwik.org/faq/how-to/faq_23654/)
 

--- a/docs/3.x/tracking-javascript-guide.md
+++ b/docs/3.x/tracking-javascript-guide.md
@@ -499,11 +499,12 @@ _paq.push(['setDomains', '*.example.com']);
 
 _paq.push(['trackPageView']);
 ```
-### Tracking multiple domain names in the same website
+### Tracking your visitors across multiple domain names in the same website 
 
-To record a visitor across different domain names into a single visit within one Piwik website, we need to setup what is called Cross Domain linking. Cross domain tracking in Piwik makes sure that when the visitor visits multiple websites and domain names, the visitor data will be stored in the same visit and that the visitor ID is reused across domain names. A typical use case where cross domain is needed is, for example, when an ecommerce online store is on `www.awesome-shop.com` and the ecommerce shopping cart technology is on another domain such as `secure.cart.com`.
+To accurately track a visitor across different domain names into a single visit within one Piwik website, we need to setup what is called Cross Domain linking. Cross domain tracking in Piwik makes sure that when the visitor visits multiple websites and domain names, the visitor data will be stored in the same visit and that the visitor ID is reused across domain names. A typical use case where cross domain is needed is, for example, when an ecommerce online store is on `www.awesome-shop.com` and the ecommerce shopping cart technology is on another domain such as `secure.cart.com`.
 
-Learn about setting up cross-domain tracking in our guide: [How do I accurately measure a same visitor across multiple domain names (cross domain linking)?](https://piwik.org/faq/how-to/faq_23654/)
+Cross domain linking uses a combination of the two tracker methods `setDomains` and `enableCrossDomainLinking`. Learn how to set up cross-domain linking in our guide: [How do I accurately measure a same visitor across multiple domain names (cross domain linking)?](https://piwik.org/faq/how-to/faq_23654/) 
+
 
 ### Tracking subdirectories of a domain in separate websites
 


### PR DESCRIPTION

Refs https://github.com/piwik/piwik/issues/2211

```
To record users across multiple domain names in the same Piwik website, we need to setup what is called Cross Domain linking. Cross domain tracking in Piwik makes sure that when the visitor visits multiple websites and domain names, the visitor data will be stored in the same visit and that the visitor ID is reused across domain names. A typical use case where cross domain is needed is for example when an ecommerce online store is on www.awesome-shop.com and the ecommerce shopping cart technology is on another domain such as secure.cart.com.

Learn about setting up cross-domain tracking in our guide: How do I accurately measure a same visitor across multiple domain names (cross domain linking)?
```