### PR TITLE
remove html entities from #id-links in sidebar

### DIFF
--- a/app/helpers/Markdown/TitleIdPreprocessor.php
+++ b/app/helpers/Markdown/TitleIdPreprocessor.php
@@ -45,6 +45,7 @@ class TitleIdPreprocessor implements MarkdownParserInterface
     {
         $headlineText = strip_tags($headlineText);
         $headlineText = trim($headlineText);
+        $headlineText = preg_replace("/&#?[a-z0-9]{2,8}; /i","",$headlineText); // remove "&amp; " from string
         $headlineText = preg_replace('/\s/', '-', $headlineText);
         $headlineText = preg_replace('/[^a-zA-Z0-9\-\_]/', '', $headlineText);
         $headlineText = preg_replace('/(\-)+/', '-', $headlineText);


### PR DESCRIPTION
(was part of #200)
The anchor links in the sidebar sometimes don't link to the correct heading
e.g.:
https://developer.piwik.org/guides/tracking-javascript-guide#enabling-download-amp-outlink-tracking
instead of
https://developer.piwik.org/guides/tracking-javascript-guide#enabling-download-outlink-tracking