### PR TITLE
fix sidebar active class

### DIFF
--- a/app/templates/left-menu.twig
+++ b/app/templates/left-menu.twig
@@ -28,7 +28,7 @@
 
                                 <ul class="nav">
                                     {% for subItem in item.subItems %}
-                                        {% set menuClass = (subItem.getMenuUrl in currentPath) ? 'active' : '' %}
+                                        {% set menuClass = (subItem.getMenuUrl == currentPath) ? 'active' : '' %}
                                         <li class="{{ menuClass }}" title="{{ subItem.title|striptags|raw }}">
                                             <a href="{{ subItem.menuUrl|completeUrl }}"> {{ subItem.menuTitle|raw }}</a>
                                         </li>


### PR DESCRIPTION
When one visits https://developer.piwik.org/api-reference/reporting-api-metadata, two items are highlighted as https://developer.piwik.org/api-reference/reporting-api is a substring