### PR TITLE
SPA guide, setCustomUrl prepend a slash

### DIFF
--- a/docs/3.x/spa-tracking.md
+++ b/docs/3.x/spa-tracking.md
@@ -112,7 +112,7 @@ In this example we show how everything works together assuming you want to track
 var currentUrl = location.href;
 window.addEventListener('hashchange', function() {
     _paq.push(['setReferrerUrl', currentUrl]);
-     currentUrl = '' + window.location.hash.substr(1);
+     currentUrl = '/' + window.location.hash.substr(1);
     _paq.push(['setCustomUrl', currentUrl]);
     _paq.push(['setDocumentTitle', 'My New Title']);
 


### PR DESCRIPTION
in the start of the article the example has a prepended slash, which looks correct to me when looking at the code of `setCustomUrl` and `resolveRelativeReference`.