### PR TITLE
Matomo Tag Manager to track Single Page Application

### DIFF
--- a/docs/3.x/spa-tracking.md
+++ b/docs/3.x/spa-tracking.md
@@ -136,7 +136,8 @@ If you're using [Tag Manager](https://matomo.org/tag-manager/) to implement your
 
 To trigger your Matomo tag (which calls `trackPageView`), you can either:
 1. use the "History change" [trigger](https://matomo.org/docs/tag-manager/#triggers) which would work in most cases,
-2. or in your Single Page App, you can trigger a Tag Manager Event `{event: 'mtm.PageView'}` by calling the following line in JavaScript: `_mtm.push({'event': 'mtm.PageView'});`
+2. or in your Single Page App, if you are using the 'Pageview Trigger' to trigger a Pageview, you can trigger a Tag Manager Event `{event: 'mtm.PageView'}` by calling the following line in JavaScript: `_mtm.push({'event': 'mtm.PageView'});`. 
+   - This would also work similarly when you use instead the 'DOM Ready Trigger' (call `_mtm.push({'event': 'mtm.DOMReady'});`) or when you use the 'Window Loaded Trigger' (call `_mtm.push({'event': 'mtm.WindowLoad'});`
 
 
 

--- a/docs/3.x/spa-tracking.md
+++ b/docs/3.x/spa-tracking.md
@@ -129,6 +129,17 @@ window.addEventListener('hashchange', function() {
     _paq.push(['enableLinkTracking']);
 });
 ```
+
+## Using Matomo Tag Manager to track Single Page Application
+
+If you're using [Tag Manager](https://matomo.org/tag-manager/) to implement your Matomo Analytics Tracking, then in your Single Page Application,  whenever there is a new page loaded in your app you will need your [Matomo Tag](https://matomo.org/docs/tag-manager/#configuring-a-tag) to be triggered for the Page view to be tracked. 
+
+To trigger your Matomo tag (which calls `trackPageView`), you can either:
+1. use the "History change" [trigger](https://matomo.org/docs/tag-manager/#triggers) which would work in most cases,
+2. or in your Single Page App, you can trigger a Tag Manager Event `{event: 'mtm.PageView'}` by calling the following line in JavaScript: `_mtm.push({'event': 'mtm.PageView'});`
+
+
+
 ## Questions?
 
 If you have any questions or need help, please [get in touch with our support team](https://matomo.org/support/) or for free support: [ask on the forum](https://forum.matomo.org).

--- a/docs/3.x/spa-tracking.md
+++ b/docs/3.x/spa-tracking.md
@@ -137,7 +137,7 @@ If you're using [Tag Manager](https://matomo.org/tag-manager/) to implement your
 To trigger your Matomo tag (which calls `trackPageView`), you can either:
 1. use the "History change" [trigger](https://matomo.org/docs/tag-manager/#triggers) which would work in most cases,
 2. or in your Single Page App, if you are using the 'Pageview Trigger' to trigger a Pageview, you can trigger a Tag Manager Event `{event: 'mtm.PageView'}` by calling the following line in JavaScript: `_mtm.push({'event': 'mtm.PageView'});`. 
-   - This would also work similarly when you use instead the 'DOM Ready Trigger' (call `_mtm.push({'event': 'mtm.DOMReady'});`) or when you use the 'Window Loaded Trigger' (call `_mtm.push({'event': 'mtm.WindowLoad'});`
+   - This would also work similarly when you use instead the 'DOM Ready Trigger' (call `_mtm.push({'event': 'DOMReady'});`) or when you use the 'Window Loaded Trigger' (call `_mtm.push({'event': 'WindowLoad'});`
 
 
 


### PR DESCRIPTION
* Adding a little section about info for SPA and Tag Manager
* Question: do we maybe need to also recommend users to create a Custom HTML tag with the following code (or similar), to reset the state correctly, when new pages are loaded within a SPA?

```
    // remove all previously assigned custom variables, requires Piwik 3.0.2
    _paq.push(['deleteCustomVariables', 'page']); 
    _paq.push(['setGenerationTimeMs', 0]);
    _paq.push(['trackPageView']);
    
    // make Matomo aware of newly added content
    var content = document.getElementById('content');
    _paq.push(['MediaAnalytics::scanForMedia', content]);
    _paq.push(['FormAnalytics::scanForForms', content]);
    _paq.push(['trackContentImpressionsWithinNode', content]);
    _paq.push(['enableLinkTracking']);
```