### PR TITLE
Remove set calling setSiteId after creating the tracker

### DIFF
--- a/docs/4.x/tracking-javascript-guide.md
+++ b/docs/4.x/tracking-javascript-guide.md
@@ -931,15 +931,6 @@ It is possible to track your analytics data into either a different website ID o
 
 The `matomoAsyncInit()` method will be executed once the Piwik tracker is loaded and initialized. In earlier versions you must load Piwik synchronous.
 
-Note that you can also set the website ID and the Piwik tracker URL manually, instead of setting them in the getTracker call:
-
-```javascript
-// we replace Matomo.getTracker("https://example.com/matomo/", 12)
-var matomoTracker = Matomo.getTracker();
-matomoTracker.setSiteId( 12 );
-matomoTracker.setTrackerUrl( "https://example.com/matomo/" );
-matomoTracker.trackPageView();
-```
 
 ## JavaScript Tracker Reference
 


### PR DESCRIPTION
I'd recommend to not mention this anymore as ideally since Matomo 3.14.0 this should be set directly in the tracker. This guarantees that when the tracker event `TrackerAdded` is triggered, that the tracker URL and tracker idSite is configured. Heatmaps and Session Recording listens to this event and tries to fetch the `configs.php` based on this event. However, it can only do this if idSite and URL is configured already. There's no event when idSite is set or anything similar. There can be otherwise edge cases when creating tracker instances manually where the configs.php is not requested when configuring the idSite later.
![image](https://user-images.githubusercontent.com/273120/87723621-29868300-c80e-11ea-99f6-2c880ebda542.png)
