### PR TITLE
Reporting API php client clarify

### DIFF
--- a/docs/4.x/reporting-api-clients.md
+++ b/docs/4.x/reporting-api-clients.md
@@ -14,7 +14,7 @@ previous: querying-the-reporting-api
 
 ### PHP client
 
-You can use directly Piwik's codebase to call the reporting API. Learn more in [Querying the reporting API](querying-the-reporting-api).
+There is currently no official Reporting API Client in PHP, but you can easily call the reporting API over HTTPS in a few lines of code. Learn more in [Querying the reporting API](querying-the-reporting-api).
 
 ### Ruby client
 


### PR DESCRIPTION
There is currently no official Reporting API Client in PHP, but you can easily call the reporting API over HTTPS in a few lines of code.

refs https://github.com/matomo-org/matomo/issues/16291