### PR TITLE
Add some basic angularjs docs to the main JS guide for upcoming angular migration

### DIFF
--- a/docs/4.x/working-with-piwiks-ui.md
+++ b/docs/4.x/working-with-piwiks-ui.md
@@ -11,20 +11,26 @@ Read this guide if you'd like to know
 
 ## JavaScript libraries
 
-Piwik uses the following JavaScript libraries:
+Matomo uses the following JavaScript libraries:
 
 * [jQuery](https://jquery.com/) and [jQuery UI](https://jqueryui.com/)
 * [AngularJS](https://angularjs.org/)
 * [jqPlot](https://www.jqplot.com/)
-* A couple of other libraries are used see our [bower dependencies](https://github.com/matomo-org/matomo/blob/master/bower.json)
+* A couple of other libraries are used see our [npm dependencies](https://github.com/matomo-org/matomo/blob/4.x-dev/package.json)
 
 **Include new JS libraries only if they are vital to your plugin.** If many plugins decide to use a custom library, the UI will slow down and plugins might get problems when different plugins load different versions of those libraries.
 
-## Assets inclusion
+## Loading JS and CSS files in the UI
 
-Plugins tell Piwik about their asset files through the [`AssetManager.getStylesheetFiles`](/api-reference/events#assetmanagergetstylesheetfiles) and [`AssetManager.getJavaScriptFiles`](/api-reference/events#assetmanagergetjavascriptfiles) events. [Event handlers](/guides/events) are registered in your plugin file (`YourPluginName.php`) and should append paths to assets to the given `$files` array:
+Plugins can tell Matomo about to load JS and CSS asset files.
+
+This is done through the [`AssetManager.getStylesheetFiles`](/api-reference/events#assetmanagergetstylesheetfiles) and [`AssetManager.getJavaScriptFiles`](/api-reference/events#assetmanagergetjavascriptfiles) events. 
+If you are new to events, check out our [events guide](/guides/events). These events are defined in your plugin file (if your plugin name was `YourPluginName` then they would be defined in `$matomoDir/plugins/YourPluginName/YourPluginName.php`). 
+
+To load a file in the UI simply append the paths that should be loaded to the given `$files` array:
 
 ```php
+// these methods need to be in your plugin php file
 public function registerEvents()
 {
     return array(
@@ -47,7 +53,7 @@ public function getJavaScriptFiles(&$files)
 
 ### Asset merging and compiling
 
-In production environments, Piwik will concatenate all JavaScript files into one and minify it. [LESS](https://lesscss.org/) files will be compiled into CSS and merged into one CSS file. Piwik does not merge and minify JavaScript and CSS files on every request as it takes a long time to do this. They are only merged on certain events, such as when enabling a new plugin.
+In production environments, Matomo will concatenate all JavaScript files into one and minify it. [LESS](https://lesscss.org/) files will be compiled into CSS and merged into one CSS file. Piwik does not merge and minify JavaScript and CSS files on every request as it takes a long time to do this. They are only merged on certain events, such as when enabling a new plugin.
 
 To make sure your changes will be actually visible and executed you need to enable the development mode in case you have not done yet:
 
@@ -56,6 +62,28 @@ To make sure your changes will be actually visible and executed you need to enab
 ```
 
 This way JavaScript files won't be merged and you can debug the original JavaScript source code.
+
+### AngularJS files
+
+If you are using Angular JS, then each plugin should put these files inside an `angularjs` directory. For example the plugin "CoreHome" defines various directives etc in [plugins/CoreHome/angularjs](https://github.com/matomo-org/matomo/tree/4.1.1/plugins/CoreHome/angularjs).
+
+We create a directory for each component which can include a directive, template, controller, etc. The naming for these files is ([click to view an example](https://github.com/matomo-org/matomo/tree/4.1.1/plugins/CoreHome/angularjs/siteselector)):
+
+* `plugins/YourPluginName/angularjs/$component-name/$component-name.controller.js`
+* `plugins/YourPluginName/angularjs/$component-name/$component-name.directive.js`
+* `plugins/YourPluginName/angularjs/$component-name/$component-name.directive.html`
+* `plugins/YourPluginName/angularjs/$component-name/$component-name.directive.less`
+* Under circumstances separate logic may be put into a model like `plugins/YourPluginName/angularjs/$component-name/$component-name.model.js`
+
+We prefer to have the controller in a separate file and not in the directive but this might not always be the case.
+
+Generic filters and services that are used by multiple components are usually defined in a `angularjs/common` directory ([see this example](https://github.com/matomo-org/matomo/tree/4.1.1/plugins/CoreHome/angularjs/common)).
+
+#### Module
+
+* The name of our module is `piwikApp`. This means you can register for example a component using `angular.module('piwikApp').component(...)`.
+* This module `piwikApp` is configured in [plugins/CoreHome/angularjs/piwikApp.js](https://github.com/matomo-org/matomo/blob/4.1.1/plugins/CoreHome/angularjs/piwikApp.js)
+
 
 ## Special HTML Elements
 


### PR DESCRIPTION
will likely remove https://developer.matomo.org/guides/angularjs-getting-started eventually as it's not really useful anymore