### PR TITLE
Add In Depth main menu item

### DIFF
--- a/app/templates/base.twig
+++ b/app/templates/base.twig
@@ -36,7 +36,6 @@
         </div>
         <div class="collapse navbar-collapse">
             <ul class="nav navbar-nav">
-                <li {% if isHome %}class="active"{% endif %}><a href="{{ '/'|completeUrl }}">Home</a></li>
                 <li {% if activeMenu == 'Integrate' %}class="active"{% endif %}>
                     <a href="{{ '/integration'|completeUrl }}">Integrate</a>
                 </li>
@@ -45,6 +44,9 @@
                 </li>
                 <li {% if activeMenu == 'API Reference' %}class="active"{% endif %}>
                     <a href="{{ '/api-reference'|completeUrl }}">API Reference</a>
+                </li>
+                <li {% if activeMenu == 'Matomo In Depth' %}class="active"{% endif %}>
+                    <a href="{{ '/piwik-in-depth'|completeUrl }}">In Depth</a>
                 </li>
                 <li {% if activeMenu == 'Changelog' %}class="active"{% endif %}>
                     <a href="{{ '/changelog'|completeUrl }}">Changelog</a>

--- a/docs/4.x/how-piwik-works.md
+++ b/docs/4.x/how-piwik-works.md
@@ -1,7 +1,7 @@
 ---
 category: DevelopInDepth
 ---
-# How Piwik Works
+# How Matomo Works
 
 ## About this guide
 

--- a/docs/4.x/http-request-handling.md
+++ b/docs/4.x/http-request-handling.md
@@ -1,7 +1,7 @@
 ---
 category: DevelopInDepth
 ---
-# How Piwik Handles HTTP Requests
+# How Matomo Handles HTTP Requests
 
 Every request that is sent to Piwik's reporting side (as opposed to Piwik's tracking side) is sent to the `index.php` file in Piwik's root directory. This file creates an instance of the [FrontController](/api-reference/Piwik/FrontController) and uses it to dispatch the current request.
 

--- a/docs/4.x/piwik-in-depth-introduction.md
+++ b/docs/4.x/piwik-in-depth-introduction.md
@@ -2,17 +2,17 @@
 category: DevelopInDepth
 title: Introduction
 ---
-# Piwik In Depth
+# Matomo In Depth
 
-Welcome to the *Matomo In Depth* section of the Piwik Developer Zone. 
-If you are interested in contributing to the Matomo core or if you want to get more insight into Piwik, you are at the right place!
+Welcome to the *Matomo In Depth* section of the Matomo Developer Zone. 
+If you are interested in contributing to the Matomo core or if you want to get more insight into Matomo, you are at the right place!
 
 This section contains guides that will help you to:
 
-- understand **how Piwik works in depth**
-- **contribute** to Piwik itself to fix bugs or add new features
+- understand **how Matomo works in depth**
+- **contribute** to Matomo itself to fix bugs or add new features
 
 Use the sidebar to navigate through the guides. Here is a list of guides to get you started:
 
-- [How Piwik Works](/guides/how-piwik-works)
-- [Contributing to Piwik Core](/guides/contributing-to-piwik-core)
+- [How Matomo Works](/guides/how-piwik-works)
+- [Contributing to Matomo Core](/guides/contributing-to-piwik-core)


### PR DESCRIPTION
Now that we have more useful guides in the Matomo In Depth section we want to expose this more so people who want to learn more about the inner workings of Matomo can more easily find this content. We removed the `Home` main menu item and instead added this new menu item.