### PR TITLE
Mention xdebug_config wont work with xdebug 3

### DIFF
--- a/docs/debugging-core.md
+++ b/docs/debugging-core.md
@@ -18,7 +18,7 @@ Using Xdebug for debugging the core will make your life a lot easier and faster.
 
 Please note that Xdebug will make running the tests run slower. Especially integration, system and UI tests. An improvement could be to have Xdebug only enabled for the web but disabled on the CLI. This way Xdebug will be disabled for integration and system tests but still run for UI tests. As a general advice for running tests faster you may want to only run a single test instead of all tests in a file like `./console tests:run file/to.php --options="--filter=test_methodNameToRun"`. 
 
-If it's not possible to disable Xdebug for CLI because there is no separate php ini file, then you may want to give it a try to have Xdebug always enabled and put something like this in your `$HOME/.profile` file: `export XDEBUG_CONFIG="remote_enable=0"` (not tested if this works).
+If it's not possible to disable Xdebug for CLI because there is no separate php ini file, then you may want to give it a try to have Xdebug always enabled and put something like this in your `$HOME/.profile` file: `export XDEBUG_CONFIG="remote_enable=0"` (does not work with Xdebug 3.x as only few options can be set using this variable).
 
 When you want to use the debugger in tests or in a CLI call (which will be needed regularly), then you could for example configure xdebug using an environment variable like below:
 


### PR DESCRIPTION
tested this today for quite a while and tried to get it working but it doesn't work with Xdebug 3. See https://xdebug.org/docs/all_settings only some settings support `XDEBUG_CONFIG` and neither `start_with_request` nor the `mode` option supports it.