### PR TITLE
fix Piwik::translate() call

### DIFF
--- a/docs/4.x/translations.md
+++ b/docs/4.x/translations.md
@@ -72,7 +72,7 @@ $translatedText = Piwik::translate('MyPlugin_BlogPost');
 or
 
 ```php
-$translatedText = Piwik::translate('MyPlugin_MyParagraphWithALink', '<a href="https://matomo.org">', '</a>');
+$translatedText = Piwik::translate('MyPlugin_MyParagraphWithALink', ['<a href="https://matomo.org">', '</a>']);
 // where the key "MyPlugin_MyParagraphWithALink" could look like this:
 // "My paragraph has a %1$slink%2$s."
 ```


### PR DESCRIPTION
The function is 
```php
public static function translate($translationId, $args = array(), $language = null)
```
so that's the only way it makes sense to call it.