### PR TITLE
remove deprecated composer option --dev

### DIFF
--- a/docs/4.x/tests-php.md
+++ b/docs/4.x/tests-php.md
@@ -48,7 +48,7 @@ $ ./console development:enable
 To install PHPUnt, run below command in the Matomo root directory (depending on how you [installed Composer](https://getcomposer.org/doc/00-intro.md) you may not need the `php` command):
 
 ```
-php composer.phar install --dev
+php composer.phar install
 ```
 
 If your development Matomo is not using `localhost` as a hostname (or if your webserver is using a custom port number), then edit your `config/config.ini.php` file and under `[tests]` section, add the `http_host` and/or `port` settings:


### PR DESCRIPTION
### Description:

The option `--dev` is DEPRECATED. The composer help says: _it enables installation of require-dev packages (enabled by default, only present for BC)_.

executing `php composer.phar install --dev` gives the warning: _You are using the deprecated option "--dev". It has no effect and will break in Composer 3._

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
