### PR TITLE
Replace Firebug links with Firefox Developer Edition

### DIFF
--- a/docs/4.x/tracking-api.md
+++ b/docs/4.x/tracking-api.md
@@ -213,7 +213,7 @@ Since Matomo 3.10 to enable the profiling of SQL queries you additionally need t
         enable_sql_profiler = 1
         
 2. Look at the HTTP requests that are sent to Piwik.
-    * If the requests take place in a browser, you can use a tool like the [Firebug](https://getfirebug.com/) to see all requests to **matomo.php**.
+    * If the requests take place in a browser, you can use a tool such as the [Firefox Developer Edition](https://www.mozilla.org/en-US/firefox/developer/) to see all requests to **matomo.php**.
     * If the requests are triggered from your app or software directly, you can output or log the output of tracking requests and to view the debug messages.
     * You can also [log messages to file or database](https://matomo.org/faq/troubleshooting/faq_115/) (requires at least Piwik 2.15.0).
 


### PR DESCRIPTION
According to the firebug site (https://getfirebug.com/), it has been replaced with Firefox Developer Edition
I haven't checked though to see if it has the same functionality as Firebug though, but it looks to include the features that Firebug had and more.

### Description:

Please include a description of this change and which issue it fixes. If no issue exists yet please include context and what problem it solves.

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
