### PR TITLE
Change order in InDepth menu to show understanding Matomo first

### DIFF
--- a/app/helpers/Content/Category/DevelopInDepthCategory.php
+++ b/app/helpers/Content/Category/DevelopInDepthCategory.php
@@ -24,8 +24,8 @@ class DevelopInDepthCategory extends Category
     {
         return [
             new Guide('piwik-in-depth-introduction'),
+            new UnlinkedCategory('in-depth-understanding-piwik'),
             new EmptySubCategory('Matomo Core development', [
-                new Guide('our-mission'),
                 new Guide('contributing-to-piwik-core'),
                 new Guide('coding-standards'),
                 new Guide('pull-request-reviews'),
@@ -40,7 +40,6 @@ class DevelopInDepthCategory extends Category
                 new Guide('release-management'),
                 new RemoteLink('Matomo\'s Roadmap', 'https://matomo.org/roadmap/'),
             ]),
-            new UnlinkedCategory('in-depth-understanding-piwik'),
             new UnlinkedCategory('in-depth-web-interface'),
             new UnlinkedCategory('in-depth-utils'),
             new UnlinkedCategory('in-depth-reporting-api'),

--- a/docs/4.x/in-depth-understanding-piwik.md
+++ b/docs/4.x/in-depth-understanding-piwik.md
@@ -2,6 +2,7 @@
 category: Develop
 title: Understanding Matomo
 subGuides:
+  - our-mission
   - how-piwik-works
   - http-request-handling
   - authentication-in-depth


### PR DESCRIPTION
Currently the menu looks like this:
![image](https://user-images.githubusercontent.com/273120/130728337-5c247bcc-f90b-41be-9927-306191302090.png)

I thought it might make sense to mention the pages "Understanding Matomo" first before "Core development" as it may be more important and more relevant to more devs see screenshot below.

Just a random thought. Happy to close without merging.

![image](https://user-images.githubusercontent.com/273120/130728261-27579af8-c505-49f0-a1ad-0615667f84fb.png)
