### PR TITLE
Added doc for TagManager.dom.onClick

### DIFF
--- a/docs/4.x/tagmanager/javascript-api-reference.md
+++ b/docs/4.x/tagmanager/javascript-api-reference.md
@@ -74,7 +74,7 @@ enabled. It will not throw an error. An error will be only thrown if `TagManager
 * `TagManager.dom.onLoad(callback)` - Triggers the callback function as soon as the page is fully loaded, including all stylesheets, images, JavaScript, etc.
 * `TagManager.dom.onReady(callback)` - Triggers the callback function as soon as the DOM is ready. This means the HTML is loaded but doesn't mean that any JavaScript, images or stylesheets have been loaded or executed.
 * `TagManager.dom.loadScriptUrl(url, options)` - Loads a JavaScript remote file by inserting a script element into the DOM. Possible options with its defaults are `{async:true,defer:true,type:'text/javascript',id:null,charset:null,onload:null,onerror:null}`.
-* `TagManager.dom.onClick(callback, element = document.body)` - Attaches a click event listener for left,middle and right click events on the element specified(default is on body). The callback has 2 arguments event and clickButton eg: callback(event, clickButton='left/right/middle')
+* `TagManager.dom.onClick(callback, element = document.body)` - Attaches a click event listener for left,middle and right click events on the element specified(default is on body). The callback has 2 arguments `event` and `clickButton` eg: `callback(event, clickButton='left/right/middle')`.
 
 ### `TagManager.window`
 

--- a/docs/4.x/tagmanager/javascript-api-reference.md
+++ b/docs/4.x/tagmanager/javascript-api-reference.md
@@ -74,6 +74,7 @@ enabled. It will not throw an error. An error will be only thrown if `TagManager
 * `TagManager.dom.onLoad(callback)` - Triggers the callback function as soon as the page is fully loaded, including all stylesheets, images, JavaScript, etc.
 * `TagManager.dom.onReady(callback)` - Triggers the callback function as soon as the DOM is ready. This means the HTML is loaded but doesn't mean that any JavaScript, images or stylesheets have been loaded or executed.
 * `TagManager.dom.loadScriptUrl(url, options)` - Loads a JavaScript remote file by inserting a script element into the DOM. Possible options with its defaults are `{async:true,defer:true,type:'text/javascript',id:null,charset:null,onload:null,onerror:null}`.
+* `TagManager.dom.onClick(callback, element = document.body)` - Attaches a click event listener for left,middle and right click events on the element specified(default is on body). The callback has 2 arguments event and clickButton eg: callback(event, clickButton='left/right/middle')
 
 ### `TagManager.window`
 


### PR DESCRIPTION
### Description:

Added doc for TagManager.dom.onClick.
Refer: https://github.com/matomo-org/tag-manager/issues/268

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
