### PR TITLE
Documentation on composer requirements

### DIFF
--- a/app/helpers/Content/Category/DevelopInDepthCategory.php
+++ b/app/helpers/Content/Category/DevelopInDepthCategory.php
@@ -38,6 +38,7 @@ class DevelopInDepthCategory extends Category
                 new Guide('reproducing-issues'),
                 new Guide('core-faqs'),
                 new Guide('core-components'),
+                new Guide('composer-dependencies'),
                 new Guide('release-management'),
                 new RemoteLink('Matomo\'s Roadmap', 'https://matomo.org/roadmap/'),
             ]),

--- a/docs/composer-dependencies.md
+++ b/docs/composer-dependencies.md
@@ -1,0 +1,73 @@
+---
+category: DevelopInDepth
+---
+# Composer dependencies
+
+Matomo requires various packages to run. Those requirements are managed using [Composer](https://getcomposer.org/).
+
+## Adding new requirements
+
+If for some reason a new requirement would be needed, we need to require it using composer.
+
+```bash
+composer require package/name ^1.2.3
+```
+
+If the required package is used for development only, it should be excluded for other environments using:
+
+```bash
+composer require-dev package/name ^1.2.3
+```
+
+## Update workflow
+
+### Minor or patch release update
+
+Almost all requirements in our `composer.json` are defined in a way that allow minor and/or patch release updates without any adjustments in `composer.json`.
+As there are normally no problems expected for those updates there is an [automatic GitHub action](https://github.com/matomo-org/matomo/blob/4.x-dev/.github/workflows/composer-update.yml) that automatically checks for updates and creates a Pull Request if any are available.
+
+### Major updates
+
+Every 6 months we should check for possible major updates of our requirements. 
+
+#### Checking for possible updates
+
+Composer allows viewing all available updates for installed packages:
+
+```bash
+composer outdated
+```
+
+#### Updating the requirements
+
+If there are major updates available we should go through them and update each. As some updates might require code changes on our side it is best to only update one requirement after the other. Otherwise it will be harder to identify why e.g. some code breaks or why some tests start failing.
+Updating a single requirement can be achieved this way:
+
+* Update the version number for the updated component in [matomo/composer.json](https://github.com/matomo-org/matomo/blob/4.x-dev/composer.json) if needed
+* Execute `composer update --with-dependencies package/name`. You need to replace `package/name` with the name of the requirement, like `phpmailer/phpmailer`. 
+* Commit & push `composer.json` and `composer.lock`.
+* Check if any tests are failing and adjust the code / tests if needed.
+* Create a PR and get it merged.
+
+*Note: we use the `--with-dependencies` option, to ensure all dependencies are updated if needed.*
+
+#### Problems with incompatible requirements
+
+It might be possible that updating some dependencies might not work due to the PHP version requirements of Matomo. 
+Some packages like `PHPUnit` might already require a higher PHP version than Matomo. 
+This causes composer not to update to newer versions or a composer install to fail when updating the dependency in `composer.json`.
+
+If an update to a newer version is mandatory there are basically two possible options
+* Increase the PHP version requirement (which is usually only done for major releases)
+* create a fork of the package and lower the minimum requirement (if the code really works with our minimum PHP requirement)
+
+*Note: If you want to install newer requirements locally for testing purpose, you can achieve this using the `--ignore-platform-reqs` option of composer.*
+
+### Updating internal packages
+
+We are managing some of our [core components](/guides/core-components) and libraries through composer as well. Whenever we release a new version of those packages we should directly issue an update of the composer requirement in Matomo.
+
+* Update the version number for the updated component in [matomo/composer.json](https://github.com/matomo-org/matomo/blob/4.x-dev/composer.json) if needed
+* Execute `composer update matomo/$COMPONENT_NAME`. You need to replace `$COMPONENT_NAME` with the name of the component. For the cache component you may need to execute `composer update matomo/cache  matomo/doctrine-cache-fork`.
+* Push `composer.json` and `composer.lock`.
+* Create a PR and get it merged.

--- a/docs/composer-dependencies.md
+++ b/docs/composer-dependencies.md
@@ -28,7 +28,16 @@ As there are normally no problems expected for those updates there is an [automa
 
 ### Major updates
 
-Every 6 months we should check for possible major updates of our requirements. 
+Every 6 months we should check for possible major updates of our requirements. These can only be upgraded if:
+
+* There is a severe security fix that's exploitable for that component
+* It still supports the same minmimum PHP version
+
+In other cases we usually cannot upgrade to a major update and need to wait for the next Matomo major release. This is to keep backwards compatibility with Matomo for WordPress, the Cloud, and also all the third party plugins on the Marketplace and the many more that aren't on the Marketplace. 
+
+There are no breaking changes is usually not a reason to be able to upgrade since there is usually always a breaking change, even if it's just a method definition that changes and then causes issues for Matomo for WordPress.
+
+For Matomo for WordPress major component updates cannot only cause issues with code that we manage, but also cause compatibility issues with the over 50,000 WordPress plugins that may use a different version of that component. Most WordPress plugins use older versions of these components where they have different classes and different method definitions and from past experience this will cause Matomo for WordPress to break suddenly, sometimes even their entire WordPress installation. This can be especially annoying with Auto-Updates in WordPress etc. We wouldn't want to break someone's installation in a minor version update whenever possible.
 
 #### Checking for possible updates
 

--- a/docs/composer-dependencies.md
+++ b/docs/composer-dependencies.md
@@ -39,6 +39,8 @@ There are no breaking changes is usually not a reason to be able to upgrade sinc
 
 For Matomo for WordPress major component updates cannot only cause issues with code that we manage, but also cause compatibility issues with the over 50,000 WordPress plugins that may use a different version of that component. Most WordPress plugins use older versions of these components where they have different classes and different method definitions and from past experience this will cause Matomo for WordPress to break suddenly, sometimes even their entire WordPress installation. This can be especially annoying with Auto-Updates in WordPress etc. We wouldn't want to break someone's installation in a minor version update whenever possible.
 
+Support for a newer PHP major version may be a reason to upgrade a component. However, if any possible we want to avoid this and rather fork the component and apply the fixes ourselves assuming it wouldn't be a 4+ days of work to do this. If it's a lot of work then we would need to assess the risk together.
+
 #### Checking for possible updates
 
 Composer allows viewing all available updates for installed packages:

--- a/docs/contributing-to-piwik-core.md
+++ b/docs/contributing-to-piwik-core.md
@@ -73,6 +73,15 @@ display_errors  = On
 error_reporting = E_ALL | E_STRICT
 ```
 
+#### Install Composer dependencies
+
+Matomo uses various libraries that are required for running Matomo. While they are included in the official releases, those [dependencies](/guides/composer-dependencies) needs to be installed manually when checking out from Git.
+To install the requirements you need to [download / install composer](https://getcomposer.org/download/) and run the following command in the Matomo directory.
+
+```bash
+composer install
+```
+
 ### Hacking Piwik
 
 Now that you have a copy of the latest Piwik source code, you can start modifying it. For this section, we'll assume there's a bug that you found and want to fix.


### PR DESCRIPTION
### Description:

We currently actually didn't really have some process for updating our composer dependencies.

I've created a new GitHub action in https://github.com/matomo-org/matomo/pull/17969 to automate minor & patch release updates.

For major updates we actually need to find a proper solution. Maybe another action could create issues if major updates are available, so we see that updates are available. Another option would be some kind of recurring task every X months to check for updates.

Might be good to discuss that, so we can adjust this documentation accordingly.

Let me know if anything else should be changed or is maybe missing.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
