### PR TITLE
Boolean configs shouldn't start with disable_

### DIFF
--- a/docs/4.x/piwiks-ini-configuration.md
+++ b/docs/4.x/piwiks-ini-configuration.md
@@ -71,8 +71,14 @@ If you want to make your plugin configurable, create a [Plugin Setting](/guides/
 
 ## Boolean Configuration Options
 
-For example `force_ssl = 1` is a boolean value in the configuration.
-By convention we check whether a feature is enabled by comparing
+### Naming
+
+It's best practice to not start a configuration's name with `disable_` but rather use `enable_`. For example, `disable_processing_unique_visitors_range = 0` is slightly harder to read for non-technical users in comparison to `enable_processing_unique_visitors_range = 1`. Note that a boolean configuration doesn't have to start with `enable_`. Some settings might not use it, for example `assume_secure_protocol = 0/1`, `multi_server_environment = 0/1`, or `force_ssl = 0/1`.
+
+### Values
+
+For example, `force_ssl = 1` is a boolean value in the configuration.
+By convention, we check whether a feature is enabled by comparing
 the setting against the value `1` like this:
 
 ```php


### PR DESCRIPTION
### Description:

Had this coming up in 2 or 3 reviews recently so thought to better document.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
