### PR TITLE
Added notes for fixing git fatal 'not our ref errors'

### DIFF
--- a/docs/git.md
+++ b/docs/git.md
@@ -240,7 +240,27 @@ The same error might happen if you point the submodule to a commit in a branch w
 * `git add plugins/SecurityInfo`
 * `git commit -m 'Update submodule'`
 * `git push`
-* 
+
+### Fixing the error "fatal: remote error: upload-pack: not our ref"
+
+The exact reason for this error is unknown at present but likely related to a failed merge. It could be accompanied with various 'warning: ... multiple configurations found for submodule.xxx' messages.
+
+To resolve this:
+
+* Save a patch of the branch changes:
+* `git diff $MAIN_BRANCH $FEATURE_BRANCH > $FEATURE_BRANCH.patch`
+* Close the PR without merging.
+* Checkout the main branch:
+* `git checkout $MAIN_BRANCH`
+* Create a new branch from the main branch:
+* `git checkout -b $FEATURE_BRANCH_NEW`
+* Apply the patch:
+* `git apply $FEATURE_BRANCH.patch`
+* Commit and push the changes:
+* `git commit -m 'New branch'`
+* `git push`
+* Create a new PR from the new branch.
+
 ### Accidentally Committed Submodules?
 
 Have you done some work on Matomo or another project and accidentally overridden the submodule commit? The below commands can help you point the submodule back to the same commit as the main branch does.


### PR DESCRIPTION
### Description:

Encountered an unusual build error in Travis when merging a branch. Added the steps I took to resolve it to the git guide.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
