### PR TITLE
Added documentation on how to fix build when test fails for a Matomo version

### DIFF
--- a/docs/4.x/tests-in-depth-faq.md
+++ b/docs/4.x/tests-in-depth-faq.md
@@ -187,7 +187,6 @@ In such case we can simply skip the tests to not run for such versions by using 
 ```php
 use Piwik\Version;
 
-
 class ApiTest extends SystemTestCase
 {
 

--- a/docs/4.x/tests-in-depth-faq.md
+++ b/docs/4.x/tests-in-depth-faq.md
@@ -181,6 +181,7 @@ public function tearDown(): void
 ```
 
 ## How do I fix a build when the tests fail for the minimum required Matomo version but pass for the latest Matomo version?
+
 There could be a case where your testcases will start failing for a specific Matomo version and pass for the latest version.
 In such case we can simply skip the tests to not run for such versions by using the `version_compare` method. Example:
 

--- a/docs/4.x/tests-in-depth-faq.md
+++ b/docs/4.x/tests-in-depth-faq.md
@@ -179,3 +179,24 @@ public function tearDown(): void
     parent::tearDown();
 }
 ```
+
+## How do I fix a build when the tests fail for the minimum required Matomo version but pass for the latest Matomo version?
+There could be a case where your testcases will start failing for a specific Matomo version and pass for the latest version.
+In such case we can simply skip the tests to not run for such versions by using the `version_compare` method. Example:
+
+```php
+use Piwik\Version;
+
+
+class ApiTest extends SystemTestCase
+{
+
+    public function testFunctionality()
+    {
+        if (version_compare(Version::VERSION, '4.4.0-b1', '>=')) {
+            //Run your testcases only when version >= 4.4.0-b1
+        }
+    }
+}
+```
+


### PR DESCRIPTION
Added documentation on how to fix build when test fails for a Matomo version

### Description:

Added documentation on how to fix build when test fails for a Matomo version.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
