### PR TITLE
Update profiling-code.md with SQL_NO_CACHE warning

### DIFF
--- a/docs/profiling-code.md
+++ b/docs/profiling-code.md
@@ -91,7 +91,7 @@ SHOW PROFILES;
 
 You can also get even more details for a query for example like this: `SHOW PROFILE CPU FOR QUERY 16;`. Learn more about this in the [MySQL docs for profiling](https://dev.mysql.com/doc/refman/8.0/en/show-profile.html).
 
-When profiling a query or generally checking how long a query takes to load, it's important to use `SQL_NO_CACHE` after the `SELECT` statement to prevent any cache from being used and giving you a wrong result.
+When profiling a query (before MySQL 5.7.20) or generally checking how long a query takes to load, it's important to use `SQL_NO_CACHE` after the `SELECT` statement to prevent any cache from being used and giving you a wrong result. Also, be aware [MySQL documentation](https://dev.mysql.com/doc/refman/5.6/en/query-cache-in-select.html) warns "that due to a limitation in the parser, a space character **must** precede and follow the SQL_NO_CACHE keyword; a nonspace such as a newline causes the server to check the query cache to see whether the result is already cached".
 
 ### Understanding query execution
 


### PR DESCRIPTION
### Description:

The documentation recommends that people use `SQL_NO_CACHE` when running different performance queries and profiling. However, we have to be careful to warn of a few SQL parser limitations that will cause the desired effect to be ignored.
 
I've also updated a few hints to what versions this applies to. SQL_NO_CACHE has been deprecated at MySQL 5.7.20, so I've noted that.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
