### PR TITLE
Retry scheduled tasks that fail

### DIFF
--- a/docs/4.x/scheduled-tasks.md
+++ b/docs/4.x/scheduled-tasks.md
@@ -90,6 +90,26 @@ public function pingSite($siteMainUrl)
     file_get_contents($siteMainUrl);
 }
 ```
+### Retrying tasks that fail
+
+By default, a scheduled task that fails with an exception will not be run again until it's next normal execution time.
+If your task fails in a way where it would be appropriate to retry, then you can throw a `Piwik\SchedulerRetryableException`. 
+The task scheduler will reschedule any task that fails with a `RetryableException` to try the task again in one hour and the retry up to a maxium of three times.
+
+```php
+public function myTask()
+{
+    try {
+        // do something
+    } catch (Exception $e) {
+        if ($e->getMessage() == "Some API: too many requests, please retry later") {
+            throw new RetryableException($e->getMessage())           
+        } else {
+            throw $e;
+        }
+    }
+}
+```
 
 ### Testing scheduled tasks
 


### PR DESCRIPTION
### Description:

Added a short explanation and example of how to retry scheduled tasks that fail by throwing a RetryableException as added by matomo-org/matomo PR 18335

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
