### PR TITLE
Suggest to use Matomo wording in link css class

### DIFF
--- a/docs/4.x/tracking-javascript-guide.md
+++ b/docs/4.x/tracking-javascript-guide.md
@@ -655,10 +655,10 @@ Learn more about this use case [Tracking subdirectories of a domain in separate 
 
 ### Tracking a click as an outlink via CSS or JavaScript
 
-If you want to force Piwik to consider a link as an outlink (links to the current domain or to one of the alias domains), you can add the 'piwik_link' css class to the link:
+If you want to force Piwik to consider a link as an outlink (links to the current domain or to one of the alias domains), you can add the 'matomo_link' css class to the link:
 
 ```html
-<a href='https://mysite.com/partner/' class='piwik_link'>Link I want to track as an outlink</a>
+<a href='https://mysite.com/partner/' class='matomo_link'>Link I want to track as an outlink</a>
 ```
 
 Note: you can customize and rename the CSS class used to force a click to be recorded as an outlink:
@@ -720,7 +720,7 @@ _paq.push(['trackPageView']);
 
 ### Recording a click as a download
 
-If you want to force Piwik to consider a link as a download, you can add the `matomo_download` or `piwik_download` css class to the link:
+If you want to force Piwik to consider a link as a download, you can add the `matomo_download` css class to the link:
 
 ```html
 <a href='last.php' class='matomo_download'>Link I want to track as a download</a>

--- a/docs/4.x/tracking-javascript-guide.md
+++ b/docs/4.x/tracking-javascript-guide.md
@@ -655,7 +655,7 @@ Learn more about this use case [Tracking subdirectories of a domain in separate 
 
 ### Tracking a click as an outlink via CSS or JavaScript
 
-If you want to force Piwik to consider a link as an outlink (links to the current domain or to one of the alias domains), you can add the 'matomo_link' css class to the link:
+If you want to force Piwik to consider a link as an outlink (links to the current domain or to one of the alias domains), you can add the `matomo_link` or `piwik_link` css class to the link:
 
 ```html
 <a href='https://mysite.com/partner/' class='matomo_link'>Link I want to track as an outlink</a>
@@ -720,7 +720,7 @@ _paq.push(['trackPageView']);
 
 ### Recording a click as a download
 
-If you want to force Piwik to consider a link as a download, you can add the `matomo_download` css class to the link:
+If you want to force Piwik to consider a link as a download, you can add the `matomo_download` or `piwik_download` css class to the link:
 
 ```html
 <a href='last.php' class='matomo_download'>Link I want to track as a download</a>


### PR DESCRIPTION
Also kept the `piwik` css class wording similar to the download CSS class so people can find it when searching for this term if they previously used the `piwik` wording.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
