### PR TITLE
Make sure data layer examples work no matter where they are copied

### DIFF
--- a/docs/3.x/spa-tracking.md
+++ b/docs/3.x/spa-tracking.md
@@ -141,8 +141,8 @@ If you're using [Tag Manager](https://matomo.org/tag-manager/) to implement your
 To trigger your Matomo tag (which calls `trackPageView`), you can either:
 
 1. use the "History change" [trigger](https://matomo.org/docs/tag-manager/#triggers) which would work in most cases,
-2. or in your Single Page App, if you are using the 'Pageview Trigger' to trigger a Pageview, you can trigger a Tag Manager Event `{event: 'mtm.PageView'}` by calling the following line in JavaScript: `_mtm.push({'event': 'mtm.PageView'});`. 
-   - This would also work similarly when you use instead the 'DOM Ready Trigger' (call `_mtm.push({'event': 'DOMReady'});`) or when you use the 'Window Loaded Trigger' (call `_mtm.push({'event': 'WindowLoad'});`
+2. or in your Single Page App, if you are using the 'Pageview Trigger' to trigger a Pageview, you can trigger a Tag Manager Event `{event: 'mtm.PageView'}` by calling the following line in JavaScript: `window._mtm.push({'event': 'mtm.PageView'});`. 
+   - This would also work similarly when you use instead the 'DOM Ready Trigger' (call `window._mtm.push({'event': 'DOMReady'});`) or when you use the 'Window Loaded Trigger' (call `window._mtm.push({'event': 'WindowLoad'});`
 
 
 

--- a/docs/3.x/tagmanager/datalayer.md
+++ b/docs/3.x/tagmanager/datalayer.md
@@ -11,7 +11,7 @@ This way you can integrate for example any ecommerce, CRM, marketing suite, and 
 
 ## Setting a variable
 
-You can push one or multiple values at once to the data layer by calling the `_mtm.push` method:
+You can push one or multiple values at once to the data layer by calling the `window._mtm.push` method:
 
 ```js
 window._mtm = window._mtm || [];

--- a/docs/3.x/tagmanager/datalayer.md
+++ b/docs/3.x/tagmanager/datalayer.md
@@ -14,12 +14,12 @@ This way you can integrate for example any ecommerce, CRM, marketing suite, and 
 You can push one or multiple values at once to the data layer by calling the `_mtm.push` method:
 
 ```js
-var _mtm = _mtm || [];
+var _mtm = window._mtm || [];
 _mtm.push({'orderTotal': 4545.45, 'orderCurrency': 'EUR'});
 ```
 
 <div markdown="1" class="alert alert-info">
-As the container will be loaded asynchronously and the variable `_mtm` may not be defined from the beginning, you may have to add a `var _mtm = _mtm || [];`.
+As the container will be loaded asynchronously and the variable `_mtm` may not be defined from the beginning, you may have to add a `var _mtm = window._mtm || [];`.
 </div>
 
 ### Configuration in Matomo Tag Manager
@@ -31,7 +31,7 @@ To access this value as a variable in Matomo Tag Manager, create a new variable 
 Triggering an event within the container works similar as setting a variable. Simply specify a property named `event` as part of the parameters:
 
 ```js
-var _mtm = _mtm || [];
+var _mtm = window._mtm || [];
 _mtm.push({'event': 'purchase', 'orderTotal': 4545.45});
 ```
 <div markdown="1" class="alert alert-info">

--- a/docs/3.x/tagmanager/datalayer.md
+++ b/docs/3.x/tagmanager/datalayer.md
@@ -14,12 +14,12 @@ This way you can integrate for example any ecommerce, CRM, marketing suite, and 
 You can push one or multiple values at once to the data layer by calling the `_mtm.push` method:
 
 ```js
-var _mtm = window._mtm || [];
-_mtm.push({'orderTotal': 4545.45, 'orderCurrency': 'EUR'});
+window._mtm = window._mtm || [];
+window._mtm.push({'orderTotal': 4545.45, 'orderCurrency': 'EUR'});
 ```
 
 <div markdown="1" class="alert alert-info">
-As the container will be loaded asynchronously and the variable `_mtm` may not be defined from the beginning, you may have to add a `var _mtm = window._mtm || [];`.
+As the container will be loaded asynchronously and the variable `window._mtm` may not be defined from the beginning, you may have to add a `window._mtm = window._mtm || [];`.
 </div>
 
 ### Configuration in Matomo Tag Manager
@@ -31,8 +31,8 @@ To access this value as a variable in Matomo Tag Manager, create a new variable 
 Triggering an event within the container works similar as setting a variable. Simply specify a property named `event` as part of the parameters:
 
 ```js
-var _mtm = window._mtm || [];
-_mtm.push({'event': 'purchase', 'orderTotal': 4545.45});
+window._mtm = window._mtm || [];
+window._mtm.push({'event': 'purchase', 'orderTotal': 4545.45});
 ```
 <div markdown="1" class="alert alert-info">
 Keep in mind that this does not send an event to Matomo, but allows you to create a tag in Matomo Tag Manager that reacts based on this event.
@@ -48,7 +48,7 @@ Assuming you created a variable "Order Total" for the `orderTotal` data layer va
 
 * Prefix your variable names with your company or application name. For example `woocommerce.orderTotal` to avoid any potential collision with other systems. If you want to use the same container logic for example for different ecommerce systems, you may want to go for a more general prefix like `ecommerce.orderTotal`.
 * Ensure the casing for the variable is correct as the data layer is case-sensitive.
-* When you define a variable, you should always enclose it in quotes as otherwise JavaScript errors may occur. Instead of `_mtm.push({order-total: 100});` use `_mtm.push({'order-total': 100});`
+* When you define a variable, you should always enclose it in quotes as otherwise JavaScript errors may occur. Instead of `window._mtm.push({order-total: 100});` use `window._mtm.push({'order-total': 100});`
 
 ## Migration from Google Tag Manager
 

--- a/docs/3.x/tagmanager/debugging.md
+++ b/docs/3.x/tagmanager/debugging.md
@@ -35,7 +35,7 @@ When you activate the preview mode, a cookie will be set in your browser that ac
 You may also enable debug messages without enabling the debug mode on the container by calling the following JavaScript code:
 
 ```js
-var _mtm = _mtm || [];
+var _mtm = window._mtm || [];
 _mtm.push(['enableDebugMode']);
 ```
 

--- a/docs/3.x/tagmanager/debugging.md
+++ b/docs/3.x/tagmanager/debugging.md
@@ -35,8 +35,8 @@ When you activate the preview mode, a cookie will be set in your browser that ac
 You may also enable debug messages without enabling the debug mode on the container by calling the following JavaScript code:
 
 ```js
-var _mtm = window._mtm || [];
-_mtm.push(['enableDebugMode']);
+window._mtm = window._mtm || [];
+window._mtm.push(['enableDebugMode']);
 ```
 
 This will log various debug messages to the developer console and is targeted to developers only. It is recommended calling this code as early as possible.

--- a/docs/3.x/tagmanager/embedding.md
+++ b/docs/3.x/tagmanager/embedding.md
@@ -23,8 +23,8 @@ The code looks as follows:
 ```html
 <!-- Matomo Tag Manager -->
 <script type="text/javascript">
-    var _mtm = window._mtm = window._mtm || [];
-    _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+    window._mtm = window._mtm || [];
+    window._mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.src='https://{$MATOMO_URL}/js/container_{$CONTAINER}.js'; s.parentNode.insertBefore(g,s);
 </script>

--- a/docs/3.x/tagmanager/integration-plugin.md
+++ b/docs/3.x/tagmanager/integration-plugin.md
@@ -29,7 +29,7 @@ Alternatively, you could also simply add this to the `<head>` (preferred) or `<b
 
 ```html
 <script type="text/javascript">
-var _mtm = _mtm || [];
+var _mtm = window._mtm || [];
 _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
 </script>
 <script type="text/javascript" src="${MATOMOURL}/js/container_${CONTAINERID}.js" async="true" defer="true"></script>

--- a/docs/3.x/tagmanager/integration-plugin.md
+++ b/docs/3.x/tagmanager/integration-plugin.md
@@ -15,8 +15,8 @@ The easiest way to embed a container without needing any authentication is to as
 ```html
 <!-- Matomo Tag Manager -->
 <script type="text/javascript">
-var _mtm = window._mtm = window._mtm || [];
-_mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+window._mtm = window._mtm || [];
+window._mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
 var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
 g.type='text/javascript'; g.async=true; g.src='${MATOMOURL}/js/container_${CONTAINERID}.js'; s.parentNode.insertBefore(g,s);
 </script>
@@ -29,8 +29,8 @@ Alternatively, you could also simply add this to the `<head>` (preferred) or `<b
 
 ```html
 <script type="text/javascript">
-var _mtm = window._mtm || [];
-_mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+window._mtm = window._mtm || [];
+window._mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
 </script>
 <script type="text/javascript" src="${MATOMOURL}/js/container_${CONTAINERID}.js" async="true" defer="true"></script>
 ```
@@ -100,27 +100,27 @@ For example if you are developing an integration for an ecommerce shop, you may 
 
 ```js
 // for example when viewing a product
-_mtm.push({'woocommerce.productName': 'My Product', 'woocommerce.productPrice': '55.45', 'woocommerce.productCurrency': 'EUR'});
+window._mtm.push({'woocommerce.productName': 'My Product', 'woocommerce.productPrice': '55.45', 'woocommerce.productCurrency': 'EUR'});
 ```
 
 You may also trigger events through the `event` attribute on certain actions such as when a user is ordering something, when a user adds to the cart, or when a user is viewing a product.
 
 ```js
 // for example when viewing a product as event
-_mtm.push({'event': 'myshop.productView', 'myshop.productName': 'My Product', 'myshop.productPrice': '55.45', 'myshop.productCurrency': 'EUR'});
+window._mtm.push({'event': 'myshop.productView', 'myshop.productName': 'My Product', 'myshop.productPrice': '55.45', 'myshop.productCurrency': 'EUR'});
 
 // for example when user adds a product to the cart
-_mtm.push({'event': 'myshop.addToCart', 'myshop.productName': 'My Product', 'myshop.productPrice': '55.45', 'myshop.productCurrency': 'EUR'});
+window._mtm.push({'event': 'myshop.addToCart', 'myshop.productName': 'My Product', 'myshop.productPrice': '55.45', 'myshop.productCurrency': 'EUR'});
 
 // for example when user purchased a product
-_mtm.push({'event': 'myshop.purchase', 'myshop.cartTotal': '55.45', 'myshop.cartCurrency': 'EUR'});
+window._mtm.push({'event': 'myshop.purchase', 'myshop.cartTotal': '55.45', 'myshop.cartCurrency': 'EUR'});
 ```
 
 A forum may add values like the currently viewed forum category, the username, etc.
 
 ```js
 // for example when viewing a product
-_mtm.push({'myforum.username': 'Myusername', 'myforum.forumCategory': 'Developers'});
+window._mtm.push({'myforum.username': 'Myusername', 'myforum.forumCategory': 'Developers'});
 ```
 
 ### Prefixing data layer variables

--- a/docs/4.x/spa-tracking.md
+++ b/docs/4.x/spa-tracking.md
@@ -140,8 +140,8 @@ If you're using [Tag Manager](https://matomo.org/tag-manager/) to implement your
 To trigger your Matomo tag (which calls `trackPageView`), you can either:
 
 1. use the "History change" [trigger](https://matomo.org/docs/tag-manager/#triggers) which would work in most cases,
-2. or in your Single Page App, if you are using the 'Pageview Trigger' to trigger a Pageview, you can trigger a Tag Manager Event `{event: 'mtm.PageView'}` by calling the following line in JavaScript: `_mtm.push({'event': 'mtm.PageView'});`. 
-   - This would also work similarly when you use instead the 'DOM Ready Trigger' (call `_mtm.push({'event': 'DOMReady'});`) or when you use the 'Window Loaded Trigger' (call `_mtm.push({'event': 'WindowLoad'});`
+2. or in your Single Page App, if you are using the 'Pageview Trigger' to trigger a Pageview, you can trigger a Tag Manager Event `{event: 'mtm.PageView'}` by calling the following line in JavaScript: `window._mtm.push({'event': 'mtm.PageView'});`. 
+   - This would also work similarly when you use instead the 'DOM Ready Trigger' (call `window._mtm.push({'event': 'DOMReady'});`) or when you use the 'Window Loaded Trigger' (call `_mtm.push({'event': 'WindowLoad'});`
 
 ## Offline Tracking
 

--- a/docs/4.x/tagmanager/datalayer.md
+++ b/docs/4.x/tagmanager/datalayer.md
@@ -19,7 +19,7 @@ _mtm.push({'orderTotal': 4545.45, 'orderCurrency': 'EUR'});
 ```
 
 <div markdown="1" class="alert alert-info">
-As the container will be loaded asynchronously and the variable `_mtm` may not be defined from the beginning, you may have to add a `var _mtm = _mtm || [];`.
+As the container will be loaded asynchronously and the variable `_mtm` may not be defined from the beginning, you may have to add a `var _mtm = window._mtm || [];`.
 </div>
 
 ### Configuration in Matomo Tag Manager

--- a/docs/4.x/tagmanager/datalayer.md
+++ b/docs/4.x/tagmanager/datalayer.md
@@ -11,7 +11,7 @@ This way you can integrate for example any ecommerce, CRM, marketing suite, and 
 
 ## Setting a variable
 
-You can push one or multiple values at once to the data layer by calling the `_mtm.push` method:
+You can push one or multiple values at once to the data layer by calling the `window._mtm.push` method:
 
 ```js
 window._mtm = window._mtm || [];
@@ -19,7 +19,7 @@ window._mtm.push({'orderTotal': 4545.45, 'orderCurrency': 'EUR'});
 ```
 
 <div markdown="1" class="alert alert-info">
-As the container will be loaded asynchronously and the variable `_mtm` may not be defined from the beginning, you may have to add a `var _mtm = window._mtm || [];`.
+As the container will be loaded asynchronously and the variable `_mtm` may not be defined from the beginning, you may have to add a `window._mtm = window._mtm || [];`.
 </div>
 
 ### Configuration in Matomo Tag Manager

--- a/docs/4.x/tagmanager/datalayer.md
+++ b/docs/4.x/tagmanager/datalayer.md
@@ -14,8 +14,8 @@ This way you can integrate for example any ecommerce, CRM, marketing suite, and 
 You can push one or multiple values at once to the data layer by calling the `_mtm.push` method:
 
 ```js
-var _mtm = window._mtm || [];
-_mtm.push({'orderTotal': 4545.45, 'orderCurrency': 'EUR'});
+window._mtm = window._mtm || [];
+window._mtm.push({'orderTotal': 4545.45, 'orderCurrency': 'EUR'});
 ```
 
 <div markdown="1" class="alert alert-info">
@@ -31,8 +31,8 @@ To access this value as a variable in Matomo Tag Manager, create a new variable 
 Triggering an event within the container works similar as setting a variable. Simply specify a property named `event` as part of the parameters:
 
 ```js
-var _mtm = window._mtm || [];
-_mtm.push({'event': 'purchase', 'orderTotal': 4545.45});
+window._mtm = window._mtm || [];
+window._mtm.push({'event': 'purchase', 'orderTotal': 4545.45});
 ```
 <div markdown="1" class="alert alert-info">
 Keep in mind that this does not send an event to Matomo, but allows you to create a tag in Matomo Tag Manager that reacts based on this event.
@@ -48,7 +48,7 @@ Assuming you created a variable "Order Total" for the `orderTotal` data layer va
 
 * Prefix your variable names with your company or application name. For example `woocommerce.orderTotal` to avoid any potential collision with other systems. If you want to use the same container logic for example for different ecommerce systems, you may want to go for a more general prefix like `ecommerce.orderTotal`.
 * Ensure the casing for the variable is correct as the data layer is case-sensitive.
-* When you define a variable, you should always enclose it in quotes as otherwise JavaScript errors may occur. Instead of `_mtm.push({order-total: 100});` use `_mtm.push({'order-total': 100});`
+* When you define a variable, you should always enclose it in quotes as otherwise JavaScript errors may occur. Instead of `window._mtm.push({order-total: 100});` use `window._mtm.push({'order-total': 100});`
 
 ## Migration from Google Tag Manager
 

--- a/docs/4.x/tagmanager/datalayer.md
+++ b/docs/4.x/tagmanager/datalayer.md
@@ -14,7 +14,7 @@ This way you can integrate for example any ecommerce, CRM, marketing suite, and 
 You can push one or multiple values at once to the data layer by calling the `_mtm.push` method:
 
 ```js
-var _mtm = _mtm || [];
+var _mtm = window._mtm || [];
 _mtm.push({'orderTotal': 4545.45, 'orderCurrency': 'EUR'});
 ```
 
@@ -31,7 +31,7 @@ To access this value as a variable in Matomo Tag Manager, create a new variable 
 Triggering an event within the container works similar as setting a variable. Simply specify a property named `event` as part of the parameters:
 
 ```js
-var _mtm = _mtm || [];
+var _mtm = window._mtm || [];
 _mtm.push({'event': 'purchase', 'orderTotal': 4545.45});
 ```
 <div markdown="1" class="alert alert-info">

--- a/docs/4.x/tagmanager/debugging.md
+++ b/docs/4.x/tagmanager/debugging.md
@@ -35,7 +35,7 @@ When you activate the preview mode, a cookie will be set in your browser that ac
 You may also enable debug messages without enabling the debug mode on the container by calling the following JavaScript code:
 
 ```js
-var _mtm = _mtm || [];
+var _mtm = window._mtm || [];
 _mtm.push(['enableDebugMode']);
 ```
 

--- a/docs/4.x/tagmanager/debugging.md
+++ b/docs/4.x/tagmanager/debugging.md
@@ -35,8 +35,8 @@ When you activate the preview mode, a cookie will be set in your browser that ac
 You may also enable debug messages without enabling the debug mode on the container by calling the following JavaScript code:
 
 ```js
-var _mtm = window._mtm || [];
-_mtm.push(['enableDebugMode']);
+window._mtm = window._mtm || [];
+window._mtm.push(['enableDebugMode']);
 ```
 
 This will log various debug messages to the developer console and is targeted to developers only. It is recommended calling this code as early as possible.

--- a/docs/4.x/tagmanager/embedding.md
+++ b/docs/4.x/tagmanager/embedding.md
@@ -23,8 +23,8 @@ The code looks as follows:
 ```html
 <!-- Matomo Tag Manager -->
 <script type="text/javascript">
-    var _mtm = window._mtm = window._mtm || [];
-    _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+    window._mtm = window._mtm || [];
+    window._mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.type='text/javascript'; g.async=true; g.src='https://{$MATOMO_URL}/js/container_{$CONTAINER}.js'; s.parentNode.insertBefore(g,s);
 </script>

--- a/docs/4.x/tagmanager/integration-plugin.md
+++ b/docs/4.x/tagmanager/integration-plugin.md
@@ -29,7 +29,7 @@ Alternatively, you could also simply add this to the `<head>` (preferred) or `<b
 
 ```html
 <script type="text/javascript">
-var _mtm = _mtm || [];
+var _mtm = window._mtm || [];
 _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
 </script>
 <script type="text/javascript" src="${MATOMOURL}/js/container_${CONTAINERID}.js" async="true" defer="true"></script>

--- a/docs/4.x/tagmanager/integration-plugin.md
+++ b/docs/4.x/tagmanager/integration-plugin.md
@@ -15,8 +15,8 @@ The easiest way to embed a container without needing any authentication is to as
 ```html
 <!-- Matomo Tag Manager -->
 <script type="text/javascript">
-var _mtm = window._mtm = window._mtm || [];
-_mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+window._mtm = window._mtm || [];
+window._mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
 var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
 g.type='text/javascript'; g.async=true; g.src='${MATOMOURL}/js/container_${CONTAINERID}.js'; s.parentNode.insertBefore(g,s);
 </script>
@@ -29,8 +29,8 @@ Alternatively, you could also simply add this to the `<head>` (preferred) or `<b
 
 ```html
 <script type="text/javascript">
-var _mtm = window._mtm || [];
-_mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+window._mtm = window._mtm || [];
+window._mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
 </script>
 <script type="text/javascript" src="${MATOMOURL}/js/container_${CONTAINERID}.js" async="true" defer="true"></script>
 ```
@@ -100,27 +100,27 @@ For example if you are developing an integration for an ecommerce shop, you may 
 
 ```js
 // for example when viewing a product
-_mtm.push({'woocommerce.productName': 'My Product', 'woocommerce.productPrice': '55.45', 'woocommerce.productCurrency': 'EUR'});
+window._mtm.push({'woocommerce.productName': 'My Product', 'woocommerce.productPrice': '55.45', 'woocommerce.productCurrency': 'EUR'});
 ```
 
 You may also trigger events through the `event` attribute on certain actions such as when a user is ordering something, when a user adds to the cart, or when a user is viewing a product.
 
 ```js
 // for example when viewing a product as event
-_mtm.push({'event': 'myshop.productView', 'myshop.productName': 'My Product', 'myshop.productPrice': '55.45', 'myshop.productCurrency': 'EUR'});
+window._mtm.push({'event': 'myshop.productView', 'myshop.productName': 'My Product', 'myshop.productPrice': '55.45', 'myshop.productCurrency': 'EUR'});
 
 // for example when user adds a product to the cart
-_mtm.push({'event': 'myshop.addToCart', 'myshop.productName': 'My Product', 'myshop.productPrice': '55.45', 'myshop.productCurrency': 'EUR'});
+window._mtm.push({'event': 'myshop.addToCart', 'myshop.productName': 'My Product', 'myshop.productPrice': '55.45', 'myshop.productCurrency': 'EUR'});
 
 // for example when user purchased a product
-_mtm.push({'event': 'myshop.purchase', 'myshop.cartTotal': '55.45', 'myshop.cartCurrency': 'EUR'});
+window._mtm.push({'event': 'myshop.purchase', 'myshop.cartTotal': '55.45', 'myshop.cartCurrency': 'EUR'});
 ```
 
 A forum may add values like the currently viewed forum category, the username, etc.
 
 ```js
 // for example when viewing a product
-_mtm.push({'myforum.username': 'Myusername', 'myforum.forumCategory': 'Developers'});
+window._mtm.push({'myforum.username': 'Myusername', 'myforum.forumCategory': 'Developers'});
 ```
 
 ### Prefixing data layer variables


### PR DESCRIPTION
Sometimes people copy these examples not into the website using a `script` tag but into their regular JS code. Copy/Pasting this code into a regular function can cause issues as _mtm may then only exist locally. For many `_paq` examples we have already changed it to `window._paq` .

By using "window." when accessing the _mtm dataLayer variable it'll always work no matter if it's executed in global context or a local context.

I didn't check any other files or docs if it's missing there too.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
