### PR TITLE
Fix link to user permissions

### DIFF
--- a/docs/4.x/wordpress/basics.md
+++ b/docs/4.x/wordpress/basics.md
@@ -33,7 +33,7 @@ current_user_can('view_matomo');
 
 Capabilities are inherited. This means a super user automatically also has admin, write and view permission.
 
-[Learn more about user permissions](https://developer.matomo/guides/permissions)
+[Learn more about user permissions](https://developer.matomo.org/guides/permissions)
 
 ## Generating links to Matomo app
 


### PR DESCRIPTION
### Description:

The link to user permissions is missing the top level domain :fearful: 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
