### PR TITLE
Added code to not replace extends PiwikUpdates to MatomoUpdates

### DIFF
--- a/app/helpers/Environment.php
+++ b/app/helpers/Environment.php
@@ -46,8 +46,8 @@ class Environment
         $replaceNew = array($newBrandOthers . ' ', ' ' . $newBrandOthers);
 
         // eg makes sure Piwik won't be replaced again
-        $keepWording = array('Matomo Developer Zone (formerly Piwik)', 'Piwik Developer Zone', 'Matomo (Piwik)', $newBrandFirst, 'Piwik.Media', 'Piwik.Form', 'Piwik.AbTest', 'Piwik.Heatmap', 'Piwik.get', 'PiwikTracker', 'typeof Piwik', '\Piwik', 'Piwik\\', 'Piwik::');
-        $keepWordingReplace = array('#_#MATOMODEVZONEFORMERLY#_#', '#_#MATOMODEVZONEFORMERLY#_#', '#_#MATOMOPIWIK#_#', '#_#saveReplace#_#', '#_#piwikmedia#_#', '#_#piwikform#_#', '#_#piwikabtest#_#', '#_#piwikheatmap#_#', '#_#piwikget#_#', '#_#piwiktracker#_#', '#_#typeofpiwik#_#', '#_#shlashpiwik#_#', '#_#piwikslash#_#','#_#piwikdoublecolon#_#');
+        $keepWording = array('Matomo Developer Zone (formerly Piwik)', 'Piwik Developer Zone', 'Matomo (Piwik)', $newBrandFirst, 'Piwik.Media', 'Piwik.Form', 'Piwik.AbTest', 'Piwik.Heatmap', 'Piwik.get', 'PiwikTracker', 'typeof Piwik', '\Piwik', 'Piwik\\', 'Piwik::', 'extends PiwikUpdates');
+        $keepWordingReplace = array('#_#MATOMODEVZONEFORMERLY#_#', '#_#MATOMODEVZONEFORMERLY#_#', '#_#MATOMOPIWIK#_#', '#_#saveReplace#_#', '#_#piwikmedia#_#', '#_#piwikform#_#', '#_#piwikabtest#_#', '#_#piwikheatmap#_#', '#_#piwikget#_#', '#_#piwiktracker#_#', '#_#typeofpiwik#_#', '#_#shlashpiwik#_#', '#_#piwikslash#_#','#_#piwikdoublecolon#_#', '#_#extendspiwikupdates#_#');
 
         $content = str_replace($keepWording, $keepWordingReplace, $content);
 


### PR DESCRIPTION
### Description:

Added code to not replace extends PiwikUpdates to MatomoUpdates.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
