### PR TITLE
Tracking API: Fix title link

### DIFF
--- a/docs/5.x/tracking-api.md
+++ b/docs/5.x/tracking-api.md
@@ -18,7 +18,7 @@ _Note: all parameters values that are strings (such as 'url', 'action\_name', et
 
 ### Recommended parameters
 
-* `action_name` **(recommended)** &mdash; The title of the action being tracked. It is possible to [use slashes / to set one or several](https://matomo.org/faq/how-to/#faq_62) [categories for this action](https://matomo.org/faq/how-to/#faq_62). For example, **Help / Feedback** will create the Action **Feedback** in the category **Help**.
+* `action_name` **(recommended)** &mdash; The title of the action being tracked. For page tracks this is used as page title. If enabled in your installation you may [use the category tree structure](https://matomo.org/faq/how-to/faq_62/) in this field. For example, “game / register new user” would then create a group “game” and add the item “register new user” in it.
 * `url` **(recommended)** &mdash; The full URL for the current action.
 * `_id` **(recommended)** &mdash; The unique visitor ID, must be a 16 characters hexadecimal string. Every unique visitor must be assigned a different ID and this ID must not change after it is assigned. If this value is not set Piwik will still track visits, but the unique visitors metric might be less accurate.
 * `rand` **(recommended)** &mdash; Meant to hold a random value that is generated before each request. Using it helps avoid the tracking request being cached by the browser or a proxy.


### PR DESCRIPTION
The current FAQ link for title categories leads to a nonexisting page. 
→ Fix the link.

This feature is also disabled by default for several years now (see https://github.com/matomo-org/matomo/pull/13688).
→ Change the description.
