### PR TITLE
Added documentation for double escaping title for piwik-field component

### DIFF
--- a/docs/core-faqs.md
+++ b/docs/core-faqs.md
@@ -14,3 +14,12 @@ Or search through the [Mozilla Developer Network](https://developer.mozilla.org/
 
 * You can check the [PHP manual](https://www.php.net/manual/en/). It will tell you which feature is supposed by which PHP versions.
 * You can also [3v4l](https://3v4l.org/) to run a specific code on 300+ different PHP versions and compare the output for each version.
+
+## How do I ensure `titles` are always escaped when using UI component `<div piwik-field data-title="YOUR_TITLE">`
+
+The `data-title` attribute is designed to display HTML correctly and due to which escaping is ignored for `HTML` and `HTML attributes`. 
+
+To ensure the text of the title is always escaped, you need to double escape it,
+Example `<div piwik-field data-title="{{ TITLE | e('html_attr') | e('html_attr')}}">`.
+
+**Note: ** You should always double escape the title, if it displays any user input or any value which can be changed by the user to avoid any XSS vulnerability.


### PR DESCRIPTION
### Description:

Added documentation for double escaping title for piwik-field component.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
