### PR TITLE
Correct submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "piwik"]
 	path = piwik
-	url = git@github.com:piwik/piwik.git
+	url = https://github.com/matomo-org/matomo.git


### PR DESCRIPTION
It seems that the old submodule path does not work anymore and points to the old place of the repository. I've updated it accordingly.