### PR TITLE
Remove return always true from composer install

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -29,9 +29,8 @@ function generateDocs {
     sleep 3
     git submodule update --recursive --force
     php ../app/composer.phar self-update
-    php ../app/composer.phar install || true
+    php ../app/composer.phar install
     cd ..
-    sleep 10
     php generator/generate.php --branch=$1 --targetname=$2
 
     GENERATION_SUCCESS=$?

--- a/generate.sh
+++ b/generate.sh
@@ -31,7 +31,7 @@ function generateDocs {
     php ../app/composer.phar self-update
     php ../app/composer.phar install || true
     cd ..
-    sleep 4
+    sleep 10
     php generator/generate.php --branch=$1 --targetname=$2
 
     GENERATION_SUCCESS=$?

--- a/generate.sh
+++ b/generate.sh
@@ -31,6 +31,7 @@ function generateDocs {
     php ../app/composer.phar self-update
     php ../app/composer.phar install
     cd ..
+    sleep 4
     php generator/generate.php --branch=$1 --targetname=$2
 
     GENERATION_SUCCESS=$?


### PR DESCRIPTION
### Description:

https://innocraft.atlassian.net/browse/WBS-1472
when running ./generate.sh the composer install command wasn't completing before the generate.php line was executing so it wasn't using the updated files. Extending the sleep seems to solve the issue.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
