### PR TITLE
Fix html sementic

### DIFF
--- a/docs/4.x/vue-getting-started.md
+++ b/docs/4.x/vue-getting-started.md
@@ -274,7 +274,7 @@ Add this attribute to your HTML like so:
   vue-entry="MyPlugin.MyComponent"
   prop-value="&quot;value for propValue property&quot;"
   my-other-property="{&quot;name&quot;: &quot;the name&quot;}"
-/>
+></div>
 ```
 
 This would mount the `MyComponent` component exported by `MyPlugin` in the div. It would pass the attribute values

--- a/docs/5.x/vue-getting-started.md
+++ b/docs/5.x/vue-getting-started.md
@@ -274,7 +274,7 @@ Add this attribute to your HTML like so:
   vue-entry="MyPlugin.MyComponent"
   prop-value="&quot;value for propValue property&quot;"
   my-other-property="{&quot;name&quot;: &quot;the name&quot;}"
-/>
+></div>
 ```
 
 This would mount the `MyComponent` component exported by `MyPlugin` in the div. It would pass the attribute values


### PR DESCRIPTION
### Description:

Doing this as stated in documentation:

``` html
<div
  vue-entry="MyPlugin.MyComponent"
  prop-value="&quot;value for propValue property&quot;"
  my-other-property="{&quot;name&quot;: &quot;the name&quot;}"
/>
```

is invalid (div tag cannot autoclose), and leads to silent error in browser or js when developing a plugin.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
