### PR TITLE
Added documentation for tests:check-direct-dependency-use command, #PG-3272

### DIFF
--- a/docs/5.x/tests-system.md
+++ b/docs/5.x/tests-system.md
@@ -197,11 +197,9 @@ class ApiTest extends SystemTestCase
 
 ## How to write a test to scan for Matomo core dependencies being used directly in your plugins
 
-With the release of Matomo `v5.1.0`, you can now check the usage of core dependencies in your plugin directly using the `tests:check-direct-dependency-use` command. With the release of Matomo 5, plugins should not use core dependencies directly but instead [prefix](https://developer.matomo.org/guides/migrate-matomo-4-to-5#vendor-proxies) them. You can also write a system test case to test the same by using the sample code below
+With the release of Matomo `5.1.0`, you can now easily check if your plugin is using any core dependencies by running the `tests:check-direct-dependency-use` command. With the release of Matomo 5, plugins should not use core dependencies directly but instead use them via [proxies](https://developer.matomo.org/guides/migrate-matomo-4-to-5#vendor-proxies). To have a check for this in your test suite and run it automatically, you can also write a system test case by using the sample code below:
 
 ```php
-<?php
-
 use Piwik\Plugins\TestRunner\Commands\CheckDirectDependencyUse;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;
 use Piwik\Version;
@@ -212,19 +210,22 @@ class CheckDirectDependencyUseCommandTest extends SystemTestCase
 {
     public function testCommand()
     {
-        if (version_compare(Version::VERSION, '5.0.2', '<=') && !\Piwik\file_exists(PIWIK_INCLUDE_PATH . '/plugins/TestRunner/Commands/CheckDirectDependencyUse.php')) {
+        if (version_compare(Version::VERSION, '5.1.0', '<=') || !file_exists(PIWIK_INCLUDE_PATH . '/plugins/TestRunner/Commands/CheckDirectDependencyUse.php')) {
             $this->markTestSkipped('tests:check-direct-dependency-use is not available in this version');
-        }
+          }
+        
         $pluginName = '{YOUR_PLUGIN_NAME}';
-        $console = new \Piwik\Console(self::$fixture->piwikEnvironment);
+        
         $checkDirectDependencyUse = new CheckDirectDependencyUse();
+        $console = new \Piwik\Console(self::$fixture->piwikEnvironment);
         $console->addCommands([$checkDirectDependencyUse]);
+        
         $command = $console->find('tests:check-direct-dependency-use');
-        $arguments = array(
-            'command'    => 'tests:check-direct-dependency-use',
+        $arguments = [
+            'command'  => 'tests:check-direct-dependency-use',
             '--plugin' => $pluginName,
-            '--grep-vendor'
-        );
+            '--grep-vendor',
+        ];
         $inputObject = new ArrayInput($arguments);
         $command->run($inputObject, new NullOutput());
 

--- a/docs/5.x/tests-system.md
+++ b/docs/5.x/tests-system.md
@@ -201,13 +201,6 @@ With release of Matomo v5.1.0, now you can check the usage of core dependencies 
 
 ```php
 <?php
-/**
- * Matomo - free/libre analytics platform
- *
- * @link https://matomo.org
- * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
- */
-namespace Piwik\Plugins\{YOUR_PLUGIN_NAME}\tests\System;
 
 use Piwik\Plugins\TestRunner\Commands\CheckDirectDependencyUse;
 use Piwik\Tests\Framework\TestCase\SystemTestCase;

--- a/docs/5.x/tests-system.md
+++ b/docs/5.x/tests-system.md
@@ -197,7 +197,7 @@ class ApiTest extends SystemTestCase
 
 ## How to write a test to scan for Matomo core dependencies being used directly in your plugins
 
-With release of Matomo v5.1.0, now you can check the usage of core dependencies in your plugin directly using the `tests:check-direct-dependency-use` command, you can also write a System test case to test the same by using below sample code.
+With the release of Matomo `v5.1.0`, you can now check the usage of core dependencies in your plugin directly using the `tests:check-direct-dependency-use` command. With the release of Matomo 5, plugins should not use core dependencies directly but instead [prefix](https://developer.matomo.org/guides/migrate-matomo-4-to-5#vendor-proxies) them. You can also write a system test case to test the same by using the sample code below
 
 ```php
 <?php


### PR DESCRIPTION
### Description:

Added documentation for tests:check-direct-dependency-use command
Fixes: #PG-3272

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
