### PR TITLE
Adding information about adding a cover image

### DIFF
--- a/docs/5.x/distributing-your-plugin.md
+++ b/docs/5.x/distributing-your-plugin.md
@@ -42,7 +42,7 @@ To make your plugin shine on the Piwik marketplace, include screenshots in your 
 Prepare a few screenshots of your plugin in action and place them in a `screenshots/` directory in your plugin's folder.
 Give them descriptive names because the file names will be used as the legends shown below each screenshot. Only alphanumeric characters, underscores and dashes are allowed in the file name. The file name must end with `.png`, `.jpg` or `.jpeg`.
 
-To add a cover image, it must be 880x480 pixels and named `_cover.png`. It can then be added to the `screenshots/` directory with the rest of the plugin screenshots. If the cover image does not fit the recommended dimensions, it may not display correctly.
+To add a cover image, it must be **880x480** pixels and named `_cover.png`. It can then be added to the `screenshots/` directory with the rest of the plugin screenshots. If the cover image does not fit the recommended dimensions, it may not display correctly.
 
 See the result for the [CustomAlerts plugin's screenshots](https://plugins.piwik.org/CustomAlerts) (click on the Screenshots link).
 These screenshots are stored [in git: CustomAlerts/screenshots](https://github.com/matomo-org/plugin-CustomAlerts/tree/master/screenshots).

--- a/docs/5.x/distributing-your-plugin.md
+++ b/docs/5.x/distributing-your-plugin.md
@@ -42,7 +42,7 @@ To make your plugin shine on the Piwik marketplace, include screenshots in your 
 Prepare a few screenshots of your plugin in action and place them in a `screenshots/` directory in your plugin's folder.
 Give them descriptive names because the file names will be used as the legends shown below each screenshot. Only alphanumeric characters, underscores and dashes are allowed in the file name. The file name must end with `.png`, `.jpg` or `.jpeg`.
 
-To add a cover image, it must be 880x480 pixels and named `_cover.png`. It can then be added to the `screenshots/` directory with the rest of the plugin screenshots. If the cover image isn't the recommended dimensions, it likely won't display properly.
+To add a cover image, it must be 880x480 pixels and named `_cover.png`. It can then be added to the `screenshots/` directory with the rest of the plugin screenshots. If the cover image does not fit the recommended dimensions, it may not display correctly.
 
 See the result for the [CustomAlerts plugin's screenshots](https://plugins.piwik.org/CustomAlerts) (click on the Screenshots link).
 These screenshots are stored [in git: CustomAlerts/screenshots](https://github.com/matomo-org/plugin-CustomAlerts/tree/master/screenshots).

--- a/docs/5.x/distributing-your-plugin.md
+++ b/docs/5.x/distributing-your-plugin.md
@@ -42,6 +42,8 @@ To make your plugin shine on the Piwik marketplace, include screenshots in your 
 Prepare a few screenshots of your plugin in action and place them in a `screenshots/` directory in your plugin's folder.
 Give them descriptive names because the file names will be used as the legends shown below each screenshot. Only alphanumeric characters, underscores and dashes are allowed in the file name. The file name must end with `.png`, `.jpg` or `.jpeg`.
 
+To add a cover image, it must be 880x480 pixels and named `_cover.png`. It can then be added to the `screenshots/` directory with the rest of the plugin screenshots. If the cover image isn't the recommended dimensions, it likely won't display properly.
+
 See the result for the [CustomAlerts plugin's screenshots](https://plugins.piwik.org/CustomAlerts) (click on the Screenshots link).
 These screenshots are stored [in git: CustomAlerts/screenshots](https://github.com/matomo-org/plugin-CustomAlerts/tree/master/screenshots).
 

--- a/docs/5.x/distributing-your-plugin.md
+++ b/docs/5.x/distributing-your-plugin.md
@@ -154,6 +154,20 @@ The following fields are not required for publishing a plugin, but you may want 
 - `wordpress-compatible`: A boolean value defining whether this plugin works in Matomo for WordPress. By default it is enabled and the Marketplace makes your plugin automatically compatible with WordPress.
 - `onpremise-compatible`: A boolean value defining whether this plugin works in Matomo On-Premise. It should usually not be needed to set this flag to disable it. If the plugin works only with WordPress, we recommend publishing it on the WordPress Marketplace instead.
 
+- `category`: A category to help group the plugin with similar plugins on the Marketplace. The available options are:
+  - `customisation` 
+  - `database` 
+  - `development` 
+  - `insights` 
+  - `integration` 
+  - `security`
+
+    For example:
+
+    ```json
+    "category": "customisation"
+    ```
+
 Here is a complete example to get you started:
 
 ```json


### PR DESCRIPTION
### Description:

It was realised that there was no documentation about adding a cover image. This PR adds some information about how to do that.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
