### PR TITLE
Add legacy Trac landing page and redirects

### DIFF
--- a/app/helpers/Content/Category/TracTicketArchiveCategory.php
+++ b/app/helpers/Content/Category/TracTicketArchiveCategory.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Piwik - Open source web analytics
+ *
+ * @link    http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace helpers\Content\Category;
+
+use helpers\Content\Guide;
+
+class TracTicketArchiveCategory extends Category
+{
+    public function getName()
+    {
+        return 'Legacy Ticket Archive';
+    }
+
+    public function getUrl()
+    {
+        return '/trac-ticket-archive';
+    }
+
+    public function getItems()
+    {
+        return [];
+    }
+
+    public function getIntroGuide()
+    {
+        return new Guide('trac-ticket-archive');
+    }
+}

--- a/app/helpers/Content/Category/TracTicketArchiveCategory.php
+++ b/app/helpers/Content/Category/TracTicketArchiveCategory.php
@@ -14,7 +14,8 @@ class TracTicketArchiveCategory extends Category
 {
     public function getName()
     {
-        return 'Legacy Ticket Archive';
+        return 'Legacy ticket archive';
+
     }
 
     public function getUrl()

--- a/app/routes/page.php
+++ b/app/routes/page.php
@@ -17,6 +17,7 @@ use helpers\Content\Category\DevelopCategory;
 use helpers\Content\Category\DevelopInDepthCategory;
 use helpers\Content\Category\IntegrateCategory;
 use helpers\Content\Category\SupportCategory;
+use helpers\Content\Category\TracTicketArchiveCategory;
 use helpers\Content\Guide;
 use helpers\Content\PhpDoc;
 use helpers\DocumentNotExistException;
@@ -163,6 +164,14 @@ $app->get('/support', function (Request $request, Response $response, $args) {
     return renderGuide($this->get("view"), $response, $request->getUri(), $category->getIntroGuide(), $category);
 });
 
+$app->get('/trac-ticket-archive', function (Request $request, Response $response, $args) {
+    $category = new TracTicketArchiveCategory();
+    return renderGuide($this->get("view"), $response, $request->getUri(), $category->getIntroGuide(), $category);
+});
+
+$app->get('/trac/ticket/{id}', function (Request $request, Response $response, $args) {
+    return $response->withStatus(301)->withHeader('Location', '/trac-ticket-archive');
+});
 
 $app->get('/changelog', function (Request $request, Response $response, $args) {
     $fetchContent = false;

--- a/docs/trac-ticket-archive.md
+++ b/docs/trac-ticket-archive.md
@@ -4,7 +4,8 @@ category: TracTicketArchiveCategory
 # Legacy ticket archive
 
 
-##Trac – Legacy Issue Tracker
+## Trac – Legacy issue tracker
+
 
 The ticket you tried to access (e.g., /trac/ticket/1647) is no longer available.
 We’ve migrated away from Trac and now use GitHub for improved collaboration and transparency.

--- a/docs/trac-ticket-archive.md
+++ b/docs/trac-ticket-archive.md
@@ -15,4 +15,4 @@ The old Trac system has been permanently shut down, and direct access to individ
 ## GitHub – Current issue tracker
 
 
-You can [create a bug report](https://github.com/matomo-org/matomo/issues) or check the status of an existing issue in our current tracking system.
+We now use [GitHub](https://github.com/matomo-org/matomo/issues) to track issues. You can [create a new issue](https://github.com/matomo-org/matomo/issues/new/choose) or check the status of an existing issue in our current tracking system.

--- a/docs/trac-ticket-archive.md
+++ b/docs/trac-ticket-archive.md
@@ -12,6 +12,7 @@ We’ve migrated away from Trac and now use GitHub for improved collaboration an
 
 The old Trac system has been permanently shut down, and direct access to individual Trac tickets is no longer possible.
 
-##[GitHub – Current Issue Tracker](https://github.com/matomo-org/matomo/issues)
+## GitHub – Current issue tracker
+
 
 You can [create a bug report](https://github.com/matomo-org/matomo/issues) or check the status of an existing issue in our current tracking system.

--- a/docs/trac-ticket-archive.md
+++ b/docs/trac-ticket-archive.md
@@ -1,7 +1,8 @@
 ---
 category: TracTicketArchiveCategory
 ---
-#Legacy Ticket Archive
+# Legacy ticket archive
+
 
 ##Trac – Legacy Issue Tracker
 

--- a/docs/trac-ticket-archive.md
+++ b/docs/trac-ticket-archive.md
@@ -1,0 +1,15 @@
+---
+category: TracTicketArchiveCategory
+---
+#Legacy Ticket Archive
+
+##Trac – Legacy Issue Tracker
+
+The ticket you tried to access (e.g., /trac/ticket/1647) is no longer available.
+We’ve migrated away from Trac and now use GitHub for improved collaboration and transparency.
+
+The old Trac system has been permanently shut down, and direct access to individual Trac tickets is no longer possible.
+
+##[GitHub – Current Issue Tracker](https://github.com/matomo-org/matomo/issues)
+
+You can [create a bug report](https://github.com/matomo-org/matomo/issues) or check the status of an existing issue in our current tracking system.


### PR DESCRIPTION
### Description:

https://innocraft.atlassian.net/browse/WBS-2217
There are thousands of links from the old Trec ticket tracker.
This creates a landing page and redirects all those links to /trac-ticket-archive
If testing locally, delete app/tmp/cache/route_cache.php to refresh the routes.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
