### PR TITLE
Adds matomo plugin directory env documentation

### DIFF
--- a/docs/5.x/how-piwik-works.md
+++ b/docs/5.x/how-piwik-works.md
@@ -225,6 +225,27 @@ Matomo Core only defines the main processes and behaviours. Plugins can extend a
 
 You can read more about this topic in the ["Matomo's Extensibility Points" guide](/guides/piwiks-extensibility-points).
 
+## Fine grained plugin directory and download control
+
+Matomo allows for a fair amount of control over where plugins are downloaded, installed, and discovered, beyond the standard `./plugins` directory. This is particularly handy in non-standard deployment configurations, such as when Matomo is deployed in containerized or read-only deployments where the core code is immutable, but you want to allow users the ability to download and install additional plugins.
+
+This is achieved through the use of the environment variables `MATOMO_PLUGIN_DIRS` and `MATOMO_PLUGIN_COPY_DIR`.
+
+### MATOMO_PLUGIN_DIRS
+
+Setting this environment variable allows you to register additional plugin locations beyond the default. It describes the plugin locations through a colon-separated list of entries, where each entry has the form `ABSOLUTE_PATH;RELATIVE_WEBROOT_PATH`. The _absolute path_ is where the plugin code lives on disk; the relative path is how that same location is exposed under the Matomo webroot (so plugin assets resolve correctly). Both parts are required, and Matomo normalizes trailing slashes.
+
+*Example:*
+`MATOMO_PLUGIN_DIRS="/var/www/html/plugins;plugins:/srv/matomo-plugins;plugins`
+
+You can declare this via environment variables, or alternatively by setting $GLOBALS['MATOMO_PLUGIN_DIRS'] in bootstrap.php.
+
+### MATOMO_PLUGIN_COPY_DIR
+
+To control where Marketplace or ZIP installs are written, set `MATOMO_PLUGIN_COPY_DIR` to one of the absolute paths already listed in MATOMO_PLUGIN_DIRS. 
+
+**Warning:** The directory must be writable by the web server user, otherwise plugin installation will fail. If the specified path is invalid or not writable, Matomo will either display an error message or fallback to installing plugins in the core `./plugins` directory, depending on the situation.
+
 
 ## Other valuable resources
 

--- a/docs/5.x/how-piwik-works.md
+++ b/docs/5.x/how-piwik-works.md
@@ -236,7 +236,7 @@ This is achieved through the use of the environment variables `MATOMO_PLUGIN_DIR
 Setting this environment variable allows you to register additional plugin locations beyond the default. It describes the plugin locations through a colon-separated list of entries, where each entry has the form `ABSOLUTE_PATH;RELATIVE_WEBROOT_PATH`. The _absolute path_ is where the plugin code lives on disk; the relative path is how that same location is exposed under the Matomo webroot (so plugin assets resolve correctly). Both parts are required, and Matomo normalizes trailing slashes.
 
 *Example:*
-`MATOMO_PLUGIN_DIRS="/var/www/html/plugins;plugins:/srv/matomo-plugins;plugins`
+`MATOMO_PLUGIN_DIRS="/var/www/html/plugins;plugins:/srv/matomo-plugins;matomo-plugins"`
 
 You can declare this via environment variables, or alternatively by setting $GLOBALS['MATOMO_PLUGIN_DIRS'] in bootstrap.php.
 


### PR DESCRIPTION
### Description:

This PR updates the developer documentation around the environment variables `MATOMO_PLUGIN_DIRS` and `MATOMO_PLUGIN_COPY_DIR` - two variables particularly helpful for containerized installations, but which seem to currently be underdocumented.

Closes #835 

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
