### PR TITLE
Fixed issue with local environment caching routes

### DIFF
--- a/app/public/index.php
+++ b/app/public/index.php
@@ -69,7 +69,7 @@ $app->add(new MatomoVersionMiddleware());
 $app->add(new CacheMiddleware());
 
 $routeCollector = $app->getRouteCollector();
-if (!CACHING_ENABLED) {
+if (CACHING_ENABLED) {
     $routeCollector->setCacheFile('../tmp/cache/route_cache.php');
 }
 


### PR DESCRIPTION
### Description:

While developing some new routes, I noticed that despite having `CACHING_ENABLED` set to false in my local config, I had to manually clear the route cache file each time I made a route path change. The line I changed appears to be doing the opposite of what you would expect and only caching routes when caching is disabled.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
