### PR TITLE
Extended existing /trac/ url redirects to avoid 404s

### DIFF
--- a/app/routes/page.php
+++ b/app/routes/page.php
@@ -169,7 +169,7 @@ $app->get('/trac-ticket-archive', function (Request $request, Response $response
     return renderGuide($this->get("view"), $response, $request->getUri(), $category->getIntroGuide(), $category);
 });
 
-$app->get('/trac/ticket/{id}', function (Request $request, Response $response, $args) {
+$app->any('/trac[/{path:.*}]', function (Request $request, Response $response, $args) {
     return $response->withStatus(301)->withHeader('Location', '/trac-ticket-archive');
 });
 

--- a/docs/trac-ticket-archive.md
+++ b/docs/trac-ticket-archive.md
@@ -1,10 +1,10 @@
 ---
 category: TracTicketArchiveCategory
 ---
-# Legacy ticket archive
+# Legacy ticket archive {#legacy-ticket-archive}
 
 
-## Trac – Legacy issue tracker
+## Trac - Legacy issue tracker {#trac-legacy-issue-tracker}
 
 
 The ticket you tried to access (e.g., /trac/ticket/1647) is no longer available.
@@ -12,7 +12,7 @@ We’ve migrated away from Trac and now use GitHub for improved collaboration an
 
 The old Trac system has been permanently shut down, and direct access to individual Trac tickets is no longer possible.
 
-## GitHub – Current issue tracker
+## GitHub - Current issue tracker {#github-current-issue-tracker}
 
 
 We now use [GitHub](https://github.com/matomo-org/matomo/issues) to track issues. You can [create a new issue](https://github.com/matomo-org/matomo/issues/new/choose) or check the status of an existing issue in our current tracking system.


### PR DESCRIPTION
### Description:

https://innocraft.atlassian.net/browse/WBS-2433
Recently a redirect was added to redirect URL’s such as /trac/ticket/1647 to https://developer.matomo.org/trac-ticket-archive.

This needs to be extended to cover the following urls as they are generating 404s

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
