### PR TITLE
Fix display of trac apostrophe

### DIFF
--- a/docs/trac-ticket-archive.md
+++ b/docs/trac-ticket-archive.md
@@ -8,11 +8,12 @@ category: TracTicketArchiveCategory
 
 
 The ticket you tried to access (e.g., /trac/ticket/1647) is no longer available.
-We’ve migrated away from Trac and now use GitHub for improved collaboration and transparency.
+We've migrated away from Trac and now use GitHub for improved collaboration and transparency.
 
 The old Trac system has been permanently shut down, and direct access to individual Trac tickets is no longer possible.
 
 ## GitHub - Current issue tracker {#github-current-issue-tracker}
+
 
 
 We now use [GitHub](https://github.com/matomo-org/matomo/issues) to track issues. You can [create a new issue](https://github.com/matomo-org/matomo/issues/new/choose) or check the status of an existing issue in our current tracking system.


### PR DESCRIPTION
### Description:

see screenshot of what it looks like on https://developer.matomo.org/trac-ticket-archive 

<img width="376" height="136" alt="image" src="https://github.com/user-attachments/assets/56f645ab-fec3-4e84-96a0-d9bed01b4f39" />

The extra newline can be ignored.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
