### PR TITLE
Cache routes only when caching enabled

### DIFF
--- a/app/public/index.php
+++ b/app/public/index.php
@@ -69,7 +69,7 @@ $app->add(new MatomoVersionMiddleware());
 $app->add(new CacheMiddleware());
 
 $routeCollector = $app->getRouteCollector();
-if (!CACHING_ENABLED) {
+if (CACHING_ENABLED) {
     $routeCollector->setCacheFile('../tmp/cache/route_cache.php');
 }
 


### PR DESCRIPTION
I pulled the latest changes from Git recently and whenever I open the changelog page locally, it would render the trac page. After a quick debug session noticed that the routes are cached despite caching disabled. I assume that this cache shouldn't be set unless caching is actually enabled. Might also give a performance update on production


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
