### PR TITLE
docs(scheduled-tasks): fix branding and RetryableException class name

### DIFF
--- a/docs/5.x/scheduled-tasks.md
+++ b/docs/5.x/scheduled-tasks.md
@@ -93,10 +93,12 @@ public function pingSite($siteMainUrl)
 ### Retrying tasks that fail
 
 By default, a scheduled task that fails with an exception will not be run again until it's next normal execution time.
-If your task fails in a way where it would be appropriate to retry, then you can throw a `Piwik\SchedulerRetryableException`. 
+If your task fails in a way where it would be appropriate to retry, then you can throw a `Piwik\Scheduler\RetryableException`. 
 The task scheduler will reschedule any task that fails with a `RetryableException` to try the task again in one hour and the retry up to a maximum of three times.
 
 ```php
+use Piwik\Scheduler\RetryableException;
+
 public function myTask()
 {
     try {

--- a/docs/5.x/scheduled-tasks.md
+++ b/docs/5.x/scheduled-tasks.md
@@ -65,12 +65,12 @@ public function remindMeToLogIn()
     $mail = new \Piwik\Mail();
     $mail->addTo('me@example.com');
     $mail->setSubject('Check stats');
-    $mail->setBodyText('Log into your Piwik instance and check your stats!');
+    $mail->setBodyText('Log into your Matomo instance and check your stats!');
     $mail->send();
 }
 ```
 
-This example sends you an email once a day to remind you to log into your Piwik daily. The Piwik platform makes sure to execute the method remindMeToLogIn exactly once every day.
+This example sends you an email once a day to remind you to log into your Matomo daily. The Matomo platform makes sure to execute the method remindMeToLogIn exactly once every day.
 
 ### Passing a parameter to a task
 
@@ -119,7 +119,7 @@ To manually execute all scheduled tasks, you can run the following command:
 $ ./console core:run-scheduled-tasks 
 ```
 
-There is one problem with this though: Piwik makes sure the scheduled tasks are executed only once an hour, a day, etc. This means you can't simply run the command again and again as you would have to wait for the next hour or day.
+There is one problem with this though: Matomo makes sure the scheduled tasks are executed only once an hour, a day, etc. This means you can't simply run the command again and again as you would have to wait for the next hour or day.
 
 To solve this, the `--force` option will force to execute all tasks, even those that are not due to run at this time.
 


### PR DESCRIPTION
## Summary
Fix outdated Piwik branding and incorrect exception class name in the scheduled tasks guide.

## Changes
- docs(scheduled-tasks): update Piwik branding to Matomo in prose text
- docs(scheduled-tasks): fix RetryableException class name and add use statement (Piwik\SchedulerRetryableException -> Piwik\Scheduler\RetryableException)

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules