### PR TITLE
docs(controllers): fix branding, AJAX API, and method name

### DIFF
--- a/docs/5.x/controllers.md
+++ b/docs/5.x/controllers.md
@@ -41,11 +41,10 @@ ajax.addParams({
     module: 'MyPlugin',
     action: 'myPage'
 }, 'get');
-ajax.setCallback(function (response) {
+ajax.setFormat('html');
+ajax.send().then(function (response) {
     $('#root').append(response);
 });
-ajax.setFormat('html');
-ajax.send();
 ```
 
 The **`ajaxHelper`** JavaScript class is stored in the [piwik/plugins/CoreHome/vue/src/AjaxHelper/AjaxHelper.ts](https://github.com/matomo-org/matomo/blob/5.x-dev/plugins/CoreHome/vue/src/AjaxHelper/AjaxHelper.ts) file.

--- a/docs/5.x/controllers.md
+++ b/docs/5.x/controllers.md
@@ -85,7 +85,7 @@ public function myControllerAction()
 
 ### Calling API methods
 
-Since controller methods do not take query parameter values as method parameters it can sometimes be a pain to invoke API methods within controller methods. In this case, controllers make use of the [Piwik\API\Request](/api-reference/Piwik/API/Request) class which will forward all query parameters to an API method. For example, let's look at some of the code in the `save()` method in the [Annotations](https://github.com/matomo-org/matomo/blob/5.x-dev/plugins/Annotations/Controller.php) plugin controller:
+Since controller methods do not take query parameter values as method parameters it can sometimes be a pain to invoke API methods within controller methods. In this case, controllers make use of the [Piwik\API\Request](/api-reference/Piwik/API/Request) class which will forward all query parameters to an API method. For example, let's look at some of the code in the `saveAnnotation()` method in the [Annotations](https://github.com/matomo-org/matomo/blob/5.x-dev/plugins/Annotations/Controller.php) plugin controller:
 
 ```php
 $view = new View('@Annotations/saveAnnotation');

--- a/docs/5.x/controllers.md
+++ b/docs/5.x/controllers.md
@@ -3,21 +3,21 @@ category: DevelopInDepth
 ---
 # Controllers
 
-In Piwik, Controllers are the objects responsible for outputting HTML. Every plugin that wants to output HTML should define its own Controller that extends [Piwik\Plugin\Controller](/api-reference/Piwik/Plugin/Controller).
+In Matomo, Controllers are the objects responsible for outputting HTML. Every plugin that wants to output HTML should define its own Controller that extends [Piwik\Plugin\Controller](/api-reference/Piwik/Plugin/Controller).
 
 Every public method in a controller is exposed and can be called through an HTTP request. **When creating your controller, care should be taken to avoid exposing methods that don't need to be. It may be possible for an attacker to use these methods.**
 
 ## Controller output
 
-Controller methods should `return` their output (as opposed to `echo`ing it). Piwik will assume the output is HTML and will automatically take care of the appropriate HTTP response headers. If you want to output something other than HTML you will have to use the `Content-Type` HTTP response header. For example:
+Controller methods should `return` their output (as opposed to `echo`ing it). Matomo will assume the output is HTML and will automatically take care of the appropriate HTTP response headers. If you want to output something other than HTML you will have to use the `Content-Type` HTTP response header. For example:
 
 ```php
 @header('Content-Type: application/json; charset=utf-8');
 ```
 
-## Using controller methods in the Piwik UI
+## Using controller methods in the Matomo UI
 
-Adding a controller method to a plugin's controller will allow it to be executed via an HTTP request, but it won't automatically show it in the Piwik UI somewhere. There are two ways to make the result of a controller method appear in the Piwik UI:
+Adding a controller method to a plugin's controller will allow it to be executed via an HTTP request, but it won't automatically show it in the Matomo UI somewhere. There are two ways to make the result of a controller method appear in the Matomo UI:
 
 * add a new menu item that links to the controller method
 * use AJAX to invoke the controller method and then display the result
@@ -26,11 +26,11 @@ Here's how you do both:
 
 ### Adding controller methods as menu items
 
-To add menu items in Piwik, read [the following guide](https://matomo.org/blog/2014/09/add-new-page-menu-item-piwik-introducing-piwik-platform/).
+To add menu items in Matomo, read [the following guide](https://matomo.org/blog/2014/09/add-new-page-menu-item-piwik-introducing-piwik-platform/).
 
 ### Invoking controller methods via AJAX
 
-If you have your own custom JavaScript running on Piwik you can use AJAX to dynamically invoke controller methods and display the result.
+If you have your own custom JavaScript running on Matomo you can use AJAX to dynamically invoke controller methods and display the result.
 
 For example:
 
@@ -60,7 +60,7 @@ Unlike API methods, controller methods do not take query parameters as input. If
 
 ### Generating Output
 
-As a plugin developer you are welcome to generate your output in any way you'd like (as long as it's secure), there is nothing in Piwik that will force you to code a certain way. That being said, most Piwik controller methods will have the following convention:
+As a plugin developer you are welcome to generate your output in any way you'd like (as long as it's secure), there is nothing in Matomo that will force you to code a certain way. That being said, most Matomo controller methods will have the following convention:
 
 ```php
 public function myControllerAction()

--- a/docs/5.x/controllers.md
+++ b/docs/5.x/controllers.md
@@ -45,7 +45,7 @@ ajax.setCallback(function (response) {
     $('#root').append(response);
 });
 ajax.setFormat('html');
-ajax.send(false);
+ajax.send();
 ```
 
 The **`ajaxHelper`** JavaScript class is stored in the [piwik/plugins/CoreHome/vue/src/AjaxHelper/AjaxHelper.ts](https://github.com/matomo-org/matomo/blob/5.x-dev/plugins/CoreHome/vue/src/AjaxHelper/AjaxHelper.ts) file.


### PR DESCRIPTION
## Summary
Fix outdated Piwik branding, modernize AJAX code example to use promise API, and correct Annotations method name.

## Changes
- Replace Piwik with Matomo in prose text (7 occurrences)
- Fix ajax.send(false) to ajax.send() - send() takes no params
- Fix Annotations method name from save() to saveAnnotation()
- Replace deprecated setCallback() with .send().then() promise pattern

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules