### PR TITLE
docs(menus): replace removed addSettingsItem() with addSystemItem()

### DIFF
--- a/docs/5.x/menus.md
+++ b/docs/5.x/menus.md
@@ -64,8 +64,8 @@ Note: URLs can be built using the controller methods:
 ```php
     public function configureAdminMenu(MenuAdmin $menu)
     {
-        // add items to an existing category
-        $menu->addSettingsItem('My admin item', $this->urlForDefaultAction());
+        // add item to an existing category
+        $menu->addSystemItem('My admin item', $this->urlForDefaultAction());
         $menu->addPlatformItem('My admin item', $this->urlForDefaultAction());
 
         // or create a custom category


### PR DESCRIPTION
## Summary
Fix removed API method in admin menu example code.

## Changes
- Replace removed addSettingsItem() with addSystemItem() in admin menu example (addSettingsItem was removed per CHANGELOG, replacement is addSystemItem)

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules