### PR TITLE
docs(extending-database): fix branding and invalid PHP syntax

### DIFF
--- a/docs/5.x/extending-database.md
+++ b/docs/5.x/extending-database.md
@@ -16,7 +16,7 @@ use Piwik\Db;
 use Piwik\Common;
 use \Exception;
 
-public class MyPlugin extends \Piwik\Plugin
+class MyPlugin extends \Piwik\Plugin
 {
     // ...
 
@@ -50,7 +50,7 @@ use Piwik\Db;
 use Piwik\Common;
 use \Exception;
 
-public class MyPlugin extends \Piwik\Plugin
+class MyPlugin extends \Piwik\Plugin
 {
     // ...
 
@@ -73,7 +73,7 @@ This would also be done in the [install](/api-reference/Piwik/Plugin#install) me
 ```php
 use Piwik\Db;
 
-public class MyPlugin extends \Piwik\Plugin
+class MyPlugin extends \Piwik\Plugin
 {
     // ...
 

--- a/docs/5.x/extending-database.md
+++ b/docs/5.x/extending-database.md
@@ -4,12 +4,12 @@ category: Develop
 # Extending the database
 
 Plugins can provide persistence for new data if they need to.
-As Piwik is currently storing all data in a MySQL database, we learn how to add new tables in the database and how to add a new data column to an existing table.
+As Matomo is currently storing all data in a MySQL database, we learn how to add new tables in the database and how to add a new data column to an existing table.
 
 
 ## Adding new tables
 
-To add new tables to Piwik's MySQL database, execute a `CREATE TABLE` statement in the plugin descriptor's [install](/api-reference/Piwik/Plugin#install) method. For example:
+To add new tables to Matomo's MySQL database, execute a `CREATE TABLE` statement in the plugin descriptor's [install](/api-reference/Piwik/Plugin#install) method. For example:
 
 ```php
 use Piwik\Db;
@@ -159,4 +159,4 @@ If a change is very useful or needed then one workaround would be to make this c
 
 ## Learn more
 
-Learn more about the Piwik Analytics database structure and tables in the [Database schema reference](/guides/database-schema).
+Learn more about the Matomo database structure and tables in the [Database schema reference](/guides/database-schema).


### PR DESCRIPTION
## Summary
Fix outdated Piwik branding and invalid PHP class declarations in the extending database guide.

## Changes
- Replace Piwik branding with Matomo in prose (3 occurrences)
- Fix invalid PHP syntax: remove `public` modifier from class declarations (PHP does not support access modifiers on classes)

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules