### PR TITLE
docs(logging): fix branding, config filename, and stale alert

### DIFF
--- a/docs/5.x/logging.md
+++ b/docs/5.x/logging.md
@@ -3,11 +3,6 @@ category: Develop
 ---
 # Logging
 
-<div class="alert alert-info" markdown="1">
-<strong>Since v2.11:</strong>
-the API described here has been introduced in Matomo 2.11 and doesn't apply to previous versions.
-</div>
-
 Logging is the action of recording events which happen while Matomo is running. It is intended to:
 
 - let users monitor the health of their Matomo installation by being able to know when minor or major errors happen

--- a/docs/5.x/logging.md
+++ b/docs/5.x/logging.md
@@ -5,17 +5,17 @@ category: Develop
 
 <div class="alert alert-info" markdown="1">
 <strong>Since v2.11:</strong>
-the API described here has been introduced in Piwik 2.11 and doesn't apply to previous versions.
+the API described here has been introduced in Matomo 2.11 and doesn't apply to previous versions.
 </div>
 
-Logging is the action of recording events which happen while Piwik is running. It is intended to:
+Logging is the action of recording events which happen while Matomo is running. It is intended to:
 
-- let users monitor the health of their Piwik installation by being able to know when minor or major errors happen
+- let users monitor the health of their Matomo installation by being able to know when minor or major errors happen
 - help users debug problems by having a detailed account of events leading to an error
 
-To log messages, Piwik uses the standardized `Psr\Log\LoggerInterface` ([PSR-3 standard](https://www.php-fig.org/psr/psr-3/)). This PHP standard lets Piwik developers use the standard interface, leaving the possibility to switch from and to *any* compatible PHP logger.
+To log messages, Matomo uses the standardized `Psr\Log\LoggerInterface` ([PSR-3 standard](https://www.php-fig.org/psr/psr-3/)). This PHP standard lets Matomo developers use the standard interface, leaving the possibility to switch from and to *any* compatible PHP logger.
 
-The PSR-3 implementation that Piwik has chosen is [Monolog](https://github.com/Seldaek/monolog). Monolog is a robust and very customizable logger used by Symfony, Silex, Laravel…
+The PSR-3 implementation that Matomo has chosen is [Monolog](https://github.com/Seldaek/monolog). Monolog is a robust and very customizable logger used by Symfony, Silex, Laravel…
 
 ## How to log messages
 
@@ -73,7 +73,7 @@ If an exception occurs, you have two choices:
 - catch it
 - not catch it and let it bubble
 
-If an exception happens and everything should be stopped and an error page should be shown, you should not catch the exception. Let it bubble and Piwik will catch it and display the exception message to the user.
+If an exception happens and everything should be stopped and an error page should be shown, you should not catch the exception. Let it bubble and Matomo will catch it and display the exception message to the user.
 
 If an exception happens but the current action should not be interrupted, you should catch the exception. If the exception was an expected case, you probably shouldn't log it. You should only log it if it's an unexpected situation that the user should be aware of.
 
@@ -93,4 +93,4 @@ In this example, we log to `error` level, but we caught the exception: the curre
 
 ### Viewing logs
 
-To view the logs, we recommend using our [LogViewer plugin](https://plugins.matomo.org/LogViewer): learn more in [How do I view Piwik application logs?](https://matomo.org/faq/how-to/faq_20991/)
+To view the logs, we recommend using our [LogViewer plugin](https://plugins.matomo.org/LogViewer): learn more in [How do I view Matomo application logs?](https://matomo.org/faq/how-to/faq_20991/)

--- a/docs/5.x/logging.md
+++ b/docs/5.x/logging.md
@@ -43,7 +43,7 @@ $this->logger->info('This is an info');
 $this->logger->debug('This is a debug message');
 ```
 
-Each of these messages will or will not be logged according to the log level configured by the user in their `config.php.ini`. Developers should not log conditionally according to the current log level: they should simply log and let the system figure it all out.
+Each of these messages will or will not be logged according to the log level configured by the user in their `config/config.ini.php`. Developers should not log conditionally according to the current log level: they should simply log and let the system figure it all out.
 
 ### Parameterized messages
 


### PR DESCRIPTION
## Summary
Fix outdated Piwik branding, incorrect config filename, and remove stale version alert from the logging guide.

## Changes
- Replace Piwik with Matomo in prose text
- Fix config filename from config.php.ini to config/config.ini.php
- Remove stale "Since v2.11" alert box (irrelevant for 5.x docs)

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules