### PR TITLE
Fix introduction pages: rebrand Piwik to Matomo and fix links

### DIFF
--- a/docs/5.x/api-reference-introduction.md
+++ b/docs/5.x/api-reference-introduction.md
@@ -4,6 +4,6 @@ title: Introduction
 ---
 # API Reference
 
-The API Reference contains low-level details on Piwik APIs and codebase.
+The API Reference contains low-level details on Matomo APIs and codebase.
 
-You will find here documentation on Piwik's HTTP APIs, JavaScript client, PHP and Java classes, methods and hooks.
+You will find here documentation on Matomo's HTTP APIs, JavaScript client, PHP classes, methods and hooks.

--- a/docs/5.x/apis.md
+++ b/docs/5.x/apis.md
@@ -24,16 +24,16 @@ Everything below is what we consider API.
     -   so far we only consider public APIs these commands: `core:archive`, `core:update`, `plugin:activate`, `plugin:deactivate`, `git:pull`, `development:enable`, `development:disable`, `customvariables:set-max-custom-variables`.
     -   some of these commands are setup in crontabs and we shouldn't break them.
 -   JavaScript variables in global `piwik.*` object
-    -   as [documented here](https://developer.piwik.org/guides/working-with-piwiks-ui#global-variables-defined-by-piwik)
+    -   as [documented here](https://developer.matomo.org/guides/working-with-piwiks-ui#global-variables-defined-by-piwik)
 -   LESS variables used for Theming
-    -   when [writing a theme for Piwik](/guides/theming) we announce that LESS variables in ([theme.less](https://github.com/piwik/piwik/blob/master/plugins/Morpheus/stylesheets/theme.less) and [theme-advanced.less](https://github.com/piwik/piwik/blob/master/plugins/Morpheus/stylesheets/theme-advanced.less)) are API
+    -   when [writing a theme for Matomo](/guides/theming) we announce that LESS variables in ([theme.less](https://github.com/matomo-org/matomo/blob/5.x-dev/plugins/Morpheus/stylesheets/theme.less) and [theme-advanced.less](https://github.com/matomo-org/matomo/blob/5.x-dev/plugins/Morpheus/stylesheets/theme-advanced.less)) are API
 -   INI Config settings names in `config/global.ini.php` are API
     -   we should not rename INI config settings as users may have overridden them in `config/config.ini.php`
 -   Widgets embed URLs are API
-    -   thousands of users include Piwik reports directly via [the iframe embed feature](http://piwik.org/docs/embed-piwik-report/) and rely on the URL to work
--   Some tools bundled with Piwik are considered API in the sense that their paths should not change:
-    -   `libs/PiwikTracker/PiwikTracker.php` <- tracker API client directly used from this path (as we advise [in our doc](https://piwik.org/docs/tracking-api/))
-    -   `misc/log-analytics/import_logs.py` <- [Log Analytics script](http://piwik.org/log-analytics/)
+    -   thousands of users include Matomo reports directly via [the iframe embed feature](https://matomo.org/docs/embed-piwik-report/) and rely on the URL to work
+-   Some tools bundled with Matomo are considered API in the sense that their paths should not change:
+    -   `libs/PiwikTracker/PiwikTracker.php` <- tracker API client directly used from this path (as we advise [in our doc](https://matomo.org/docs/tracking-api/))
+    -   `misc/log-analytics/import_logs.py` <- [Log Analytics script](https://matomo.org/log-analytics/)
     -   `piwik.js` is the minified JavaScript tracking client referenced in Tracking code in users' websites
     -   alternatively `/js/` endpoint is sometimes used to serve the minified file ensuring caching of the file in browsers.
 
@@ -84,7 +84,7 @@ When we are adding a new API or when we are breaking or deprecating an existing 
 * change to Reporting API output (eg. a new field in an API response)
 * change to Reporting API parameter (eg. parameter added, deprecated, removed)
 * change to Tracking API parameter (eg. parameter added, deprecated, removed)
-* change to Piwik JavaScript Tracker feature (eg. new feature, or removed feature)
+* change to Matomo JavaScript Tracker feature (eg. new feature, or removed feature)
 * since PHP 8 argument names of public API's are also considered API
 * new console command
 * new config.ini.php settings

--- a/docs/5.x/design-introduction.md
+++ b/docs/5.x/design-introduction.md
@@ -5,7 +5,7 @@ subGuides:
 ---
 # Themes
 
-In Piwik, themes are special types of plugins that change the look and feel of Piwik's UI.
-They use CSS and LESS to override the default styles defined by other Piwik plugins.
+In Matomo, themes are special types of plugins that change the look and feel of Matomo's UI.
+They use CSS and LESS to override the default styles defined by other Matomo plugins.
 
-The following guides will help you create your own theme to customize how Piwik looks.
+The following guides will help you create your own theme to customize how Matomo looks.

--- a/docs/5.x/develop-introduction.md
+++ b/docs/5.x/develop-introduction.md
@@ -4,9 +4,9 @@ title: Introduction
 ---
 # Develop
 
-Welcome to the *Develop* section of the Piwik Developer Zone. If you are interested in customizing Matomo, you are in the right place!
+Welcome to the *Develop* section of the Matomo Developer Zone. If you are interested in customizing Matomo, you are in the right place!
 
-This section contains guides that will help you create **Plugins** and **Themes** to customize Matomo (Piwik), or to add new features to Matomo.
+This section contains guides that will help you create **Plugins** and **Themes** to customize Matomo, or to add new features to Matomo.
 
 If you want to get more insight into how Matomo works behind the API's check out our [Matomo In Depth](/piwik-in-depth) section.
 

--- a/docs/5.x/integrate-introduction.md
+++ b/docs/5.x/integrate-introduction.md
@@ -2,11 +2,11 @@
 category: Integrate
 title: Introduction
 ---
-# Integrate Piwik
+# Integrate Matomo
 
-Welcome to the *Integrate* section of the Piwik Developer Zone. If you are interested in integrating Matomo with your application, you are at the right place!
+Welcome to the *Integrate* section of the Matomo Developer Zone. If you are interested in integrating Matomo with your application, you are at the right place!
 
 This section contains guides that will help you to:
 
 - track your website, mobile application, etc. using the **Tracking API**
-- query and use Piwik data by using the **Reporting API**
+- query and use Matomo data by using the **Reporting API**

--- a/docs/5.x/piwiks-extensibility-points.md
+++ b/docs/5.x/piwiks-extensibility-points.md
@@ -3,15 +3,15 @@ category: DevelopInDepth
 ---
 # Matomo's Extensibility Points
 
-Plugins can extend Piwik using the following methods:
+Plugins can extend Matomo using the following methods:
 
 - using **events** see [Events](/guides/events)
-- implementing **special classes** that are recognized by Piwik see [Plugin Basics under Develop](/develop)
+- implementing **special classes** that are recognized by Matomo see [Plugin Basics under Develop](/develop)
 
 ## Learn More
 
-* To learn **about every event that Piwik posts** [read the event docs](/api-reference/events).
-* To learn **more about the Twig filters and functions Piwik defines** read the documentation for the [View](/api-reference/Piwik/View) class.
+* To learn **about every event that Matomo posts** [read the event docs](/api-reference/events).
+* To learn **more about the Twig filters and functions Matomo defines** read the documentation for the [View](/api-reference/Piwik/View) class.
 * To learn **about API and Controller classes** read our [Controllers](/guides/controllers) or [APIs](/guides/apis) guides.
 * To learn **about Archiver classes** read our [Archiving](/guides/archiving) guide.
 * To learn **about plugin settings** read our [Plugin Settings](/guides/plugin-settings) guide.

--- a/docs/5.x/reporting-api-clients.md
+++ b/docs/5.x/reporting-api-clients.md
@@ -8,7 +8,7 @@ previous: querying-the-reporting-api
 
 **Read this guide if**
 
-* you'd like to know **which client libraries are available to use [Piwik's Reporting HTTP API](https://developer.matomo.org/guides/reporting-introduction) from your application**
+* you'd like to know **which client libraries are available to use [Matomo's Reporting HTTP API](https://developer.matomo.org/guides/reporting-introduction) from your application**
 
 ## Client libraries for Reporting API
 
@@ -48,4 +48,4 @@ If you're looking instead for client libraries to use Matomo Tracking HTTP API a
 
 ## Learn more
 
-You can view the complete list of clients and integrations of Piwik at [matomo.org/integrate/](https://matomo.org/integrate/).
+You can view the complete list of clients and integrations of Matomo at [matomo.org/integrate/](https://matomo.org/integrate/).

--- a/docs/5.x/reporting-introduction.md
+++ b/docs/5.x/reporting-introduction.md
@@ -5,9 +5,9 @@ subGuides:
   - querying-the-reporting-api
   - reporting-api-clients
 ---
-# Accessing Piwik data
+# Accessing Matomo data
 
-This section contains guides that will help you query Piwik's reporting data to integrate it into your application.
+This section contains guides that will help you query Matomo's reporting data to integrate it into your application.
 
 ## API references
 

--- a/docs/5.x/tracking-introduction.md
+++ b/docs/5.x/tracking-introduction.md
@@ -10,7 +10,7 @@ subGuides:
 ---
 # Tracking your application
 
-This section contains guides that will help you track your application using Piwik.
+This section contains guides that will help you track your application using Matomo.
 
 ## API references
 


### PR DESCRIPTION
## Summary
Rebrand Piwik to Matomo across multiple introduction and overview pages, fix GitHub links, theme.less paths, and remove incorrect Java classes claim.

## Changes
- docs(reporting-api-clients): rebrand Piwik to Matomo
- docs(tracking-introduction): rebrand Piwik to Matomo
- docs(reporting-introduction): rebrand Piwik to Matomo
- docs(integrate-introduction): rebrand Piwik to Matomo
- docs(piwiks-extensibility-points): rebrand Piwik to Matomo in prose
- docs(develop-introduction): rebrand Piwik to Matomo
- docs(design-introduction): rebrand Piwik to Matomo
- docs(apis): rebrand Piwik to Matomo, fix GitHub links and theme.less paths
- docs(api-reference-introduction): rebrand Piwik to Matomo and remove incorrect Java classes claim

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules