### PR TITLE
Fix API docs: correct method name and rebrand Piwik to Matomo

### DIFF
--- a/docs/5.x/querying-the-reporting-api.md
+++ b/docs/5.x/querying-the-reporting-api.md
@@ -5,9 +5,9 @@ next: reporting-api-clients
 ---
 # Querying the Reporting API
 
-This guide explains how to call the Piwik API to request your web analytics data. 
+This guide explains how to call the Matomo API to request your web analytics data. 
 
-## Call the Piwik API using the HTTP API
+## Call the Matomo API using the HTTP API
 
 If you want to request data in any language (PHP, Python, Ruby, ASP, C++, Java, etc.) you can use the HTTP API. It is a simple way to request data via an HTTP GET.
 

--- a/docs/5.x/request-parameters.md
+++ b/docs/5.x/request-parameters.md
@@ -110,12 +110,12 @@ If your parameters does not have a specific type you may use the following metho
   $request->getArrayParameter(string $name, array $default = null): array
   ```
 
-* **JSON encoded data** / **getJSONParameter()**
+* **JSON encoded data** / **getJsonParameter()**
 
   If the data of your parameter should contain a json encoded string, you can use this method, to directly receive the parameters values decoded. The returned type though might contain any type of data, so handle it with care.
 
   ```php
-  $request->getJSONParameter(string $name, mixed $default = null): mixed
+  $request->getJsonParameter(string $name, mixed $default = null): mixed
   ```
 
 * **Unspecific type** / **getParameter()**


### PR DESCRIPTION
## Summary
Fix incorrect getJSONParameter method name to getJsonParameter in request parameters doc, and rebrand Piwik to Matomo in querying the reporting API doc.

## Changes
- docs(request-parameters): fix getJSONParameter to getJsonParameter
- docs(querying-the-reporting-api): replace Piwik with Matomo in API references

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules