### PR TITLE
Fix crash analytics docs: correct method names and parameters

### DIFF
--- a/docs/5.x/crash-analytics/options.md
+++ b/docs/5.x/crash-analytics/options.md
@@ -37,7 +37,7 @@ To **limit the total number of of requests per tracker**, use the `setMaxNoOfCra
 _paq.push(["CrashAnalytics::setMaxNoOfCrashRequestsAllowed", 100]);
 ```
 
-If a tracker reaches this limit, it will stop sending Crash Analytics requests entirely. The only way requests are sent again is if the user reloads the page.
+If a tracker reaches this limit, it will stop sending Crash Analytics requests entirely. The counter resets when the user reloads the page or when a pageview is tracked (e.g., via `trackPageView`).
 
 By default, trackers are limited to 50 Crash Analytics requests per page view.
 
@@ -74,13 +74,13 @@ _paq.push(["CrashAnalytics::doNotTrackSourcesWithDomain", ["facebook.com", "some
 To ignore every domain **except** the ones you care about, use the `onlyTrackSourcesWithDomain()` method:
 
 ```js
-_paq.push(["CrashAnalytics::onlyTrackSourcesWithDomain", ["mysite.com"]);
+_paq.push(["CrashAnalytics::onlyTrackSourcesWithDomain", "mysite.com"]);
 ```
 
 ## How can I make sure browser extension errors are tracked?
 
-By default, the JavaScript tracker will ignore errors that come from browser extensions. If instead you’d like to see these errors, use the `trackBrowserExtensionErrors()` method:
+By default, the JavaScript tracker will ignore errors that come from browser extensions. If instead you’d like to see these errors, use the `trackBrowserExtensionCrashes()` method:
 
 ```js
-_paq.push(["CrashAnalytics::trackBrowserExtensionErrors"]);
+_paq.push(["CrashAnalytics::trackBrowserExtensionCrashes"]);
 ```

--- a/docs/5.x/crash-analytics/reference.md
+++ b/docs/5.x/crash-analytics/reference.md
@@ -14,9 +14,9 @@ In the `matomo.js` tracker we differentiate between two kind of methods:
 
 * Calling a **tracker instance method** affects only a specific Matomo tracker instance. In the docs you can
   identify a tracker method when the method name contains a single dot (`.`), for example
-  `CrashAnalytics.disableTrackEvents`.
+  `CrashAnalytics.disable`.
 * Calling a **static method** affects all created tracker instances. In the docs you can identify a static method when
-  the method name contains `::`, for example `CrashAnalytics::removePlayer`.
+  the method name contains `::`, for example `CrashAnalytics::setSampleRate`.
 
 In most cases only one Matomo tracker will be used so the only difference is how you call that method:
 
@@ -27,7 +27,7 @@ In most cases only one Matomo tracker will be used so the only difference is how
   eg. `Matomo.CrashAnalytics.$methodName()`.
 
 If you do not want to use the `_paq.push` methods, you need to define a `window.matomoCrashAnalyticsAsyncInit` method
-that is called as soon as the media tracker has been initialized:
+that is called as soon as the crash analytics tracker has been initialized:
 
 ```js
 window.matomoCrashAnalyticsAsyncInit = function () {
@@ -49,7 +49,7 @@ Returns the configured “sample rate”. See documentation for `setSampleRate()
 
 Sets the maximum number of crash requests that are allowed to be sent per tracker. Once this limit is reached, no further crash tracking requests are sent. Defaults to 50.
 
-Note: if the page is reloaded the count of crash requests sent resets, but if a pageview is tracked, it will not reset. This is significant if you’re using this functionality within a single page application where actual page loads/reloads may be rare.
+Note: the count of crash requests sent resets when the page is reloaded or when a pageview is tracked (e.g., via `trackPageView`).
 
 ### `getMatomoTrackers()`
 
@@ -102,9 +102,9 @@ Allows you to limit crash tracking to crashes that originate from a source file 
 
 Allows you to exclude crashes from crash tracking if they originate from a source file hosted on one or a list of domains. If you use JavaScript from another organization or product that you have no control over, for instance, you can ignore any crashes that occur from those source files with this method.
 
-### `trackBrowserExtensionErrors()`
+### `trackBrowserExtensionCrashes()`
 
-Some browsers will report crashes that occur in browser extensions to the website causing them to be tracked in Matomo. By default these crashes are ignored, but if you’d like them to be tracked, you can call `trackBrowserExtensionErrors()`.
+Some browsers will report crashes that occur in browser extensions to the website causing them to be tracked in Matomo. By default these crashes are ignored, but if you’d like them to be tracked, you can call `trackBrowserExtensionCrashes()`.
 
 ### `doNotTrackBrowserExtensions()`
 
@@ -151,21 +151,21 @@ Enables the debug mode that logs debug information to the developer console of y
 
 ### `enable()`
 
-Disables the tracking of crashes for a specific tracker instance.
+If crash tracking was disabled via `disable()`, you can enable it again for a specific tracker instance using this method.
 
 Example:
 ```js
-// disables the tracking of events on all Matomo trackers
-_paq.push([‘CrashAnalytics.disable’]);
+// enables the tracking of crashes on all Matomo trackers
+_paq.push([‘CrashAnalytics.enable’]);
 
-// or if you are using multiple Matomo trackers and only want to disable it for a specific tracker:
+// or if you are using multiple Matomo trackers and only want to enable it for a specific tracker:
 var tracker = Matomo.getAsyncTracker(matomoUrl, matomoSiteId);
-tracker.CrashAnalytics.disable();
+tracker.CrashAnalytics.enable();
 ```
 
 ### `disable()`
 
-If the tracking of crashes was disabled via `disableTrackEvents()`, you can enable it again using this method.
+Disables the tracking of crashes for a specific tracker instance.
 
 ### `isEnabled()`
 

--- a/docs/5.x/crash-analytics/server.md
+++ b/docs/5.x/crash-analytics/server.md
@@ -14,7 +14,7 @@ For available methods please check the tracker SDK documentation.
 
 ### How to track exceptions with the PHP tracker?
 
-To track an exception you caught, use the `trackPhpThrowable()` method:
+To track an exception you caught, use the `doTrackPhpThrowable()` method:
 
 ```php
 $tracker = new \MatomoTracker(...);
@@ -22,11 +22,11 @@ $tracker = new \MatomoTracker(...);
 try {
     doSomeComplicatedTask();
 } catch (\Throwable $ex) {
-    $tracker->trackPhpThrowable($ex);
+    $tracker->doTrackPhpThrowable($ex);
 }
 ```
 
-Like the JavaScript tracker, this method will deduce as much information as possible from the exception, including the stack trace, source line and column, and error type.
+Like the JavaScript tracker, this method will deduce as much information as possible from the exception, including the stack trace, source line, and error type.
 
 #### Manual track crashing with the PHP tracker
 
@@ -36,7 +36,7 @@ There is also a method that can be used to track a crash or error if you don’t
 $tracker = new \MatomoTracker(...);
 
 if (!is_file('myveryimportantfile')) {
-    $tracker->trackCrash('myveryimportantfile is expected, but cannot be found!', 'IllegalState', 'my category', $stack = null, __FILE__);
+    $tracker->doTrackCrash('myveryimportantfile is expected, but cannot be found!', 'IllegalState', 'my category', $stack = null, __FILE__);
     return;
 }
 ```
@@ -46,6 +46,6 @@ Though you can also simply create an exception which in most cases would be simp
 ```php
 $tracker = new \MatomoTracker(...);
 if (!is_file('myveryimportantfile')) {
-    $tracker->trackPhpThrowable(new IllegalStateException('myveryimportantfile is expected, but cannot be found!'));
+    $tracker->doTrackPhpThrowable(new \RuntimeException('myveryimportantfile is expected, but cannot be found!'));
 }
 ```

--- a/docs/5.x/crash-analytics/setup.md
+++ b/docs/5.x/crash-analytics/setup.md
@@ -87,6 +87,6 @@ _paq.push(["CrashAnalytics::trackCrash", "my error message", "my error type"]);
 You can also set a custom stack trace, category, line number and column number this way:
 
 ```js
-_paq.push(["CrashAnalytics::trackCrash", "my error message", "my error type", "my category", "a custom stack trace value", 50, 60]);
+_paq.push(["CrashAnalytics::trackCrash", "my error message", "my error type", "my category", "a custom stack trace value", null, 50, 60]);
 ```
 


### PR DESCRIPTION
## Summary
Fix multiple inaccuracies in crash analytics documentation including missing parameters in trackCrash example, incorrect method names, and wrong parameter types.

## Changes
- docs(crash-analytics/setup): fix trackCrash example missing location param
- docs(crash-analytics/reference): fix multiple inaccuracies
- docs(crash-analytics/options): fix method names and parameter types
- docs(crash-analytics/server): fix PHP tracker method names

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules