### PR TITLE
Fix database docs: remove syntax error and update link

### DIFF
--- a/docs/5.x/database.md
+++ b/docs/5.x/database.md
@@ -37,7 +37,7 @@ If you need to change data (insert, update, delete, alter), there are two method
 Example:
 
 ```php
-$sql = sprintf('INSERT INTO table_name (`key`, `value`, `expiry_time`) VALUES (?,?,(UNIX_TIMESTAMP() + ?))';
+$sql = 'INSERT INTO table_name (`key`, `value`, `expiry_time`) VALUES (?,?,(UNIX_TIMESTAMP() + ?))';
 $db->query($sql, array($key, $value, (int) $ttlInSeconds));
 ```
 

--- a/docs/5.x/database.md
+++ b/docs/5.x/database.md
@@ -16,7 +16,7 @@ There are various methods available to query data like:
 * `fetchOne` - return only one value
 * `fetchRow` - return only one row as an array
 * `fetchAll` - return all matching rows as an array
-* `query`    - returns a [Zend_Db_Statement](http://framework.zend.com/manual/1.12/en/zend.db.statement.html) which lets you iterate over each row, get the row count, and more.
+* `query`    - returns a [Zend_Db_Statement](https://framework.zend.com/manual/1.12/en/zend.db.statement.html) which lets you iterate over each row, get the row count, and more.
 
 All of these support binding parameters using place holders (`?`) for security to prevent SQL injections, for example:
 


### PR DESCRIPTION
## Summary
Remove unclosed sprintf() from query example and update Zend_Db_Statement link to HTTPS.

## Changes
- docs(database): remove unclosed sprintf() from query example
- docs(database): update Zend_Db_Statement link to HTTPS

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules