### PR TITLE
Fix database schema docs: update table columns to match current schema

### DIFF
--- a/docs/5.x/database-schema.md
+++ b/docs/5.x/database-schema.md
@@ -412,6 +412,9 @@ The following information is stored in the `segment` table in a segment entity:
 - `ts_created`: the date when the segment was created.
 - `ts_last_edit`: the date when the segment was last edited.
 - `deleted`: set to `1` when a segment is deleted.
+- `hash`: a hash of the segment definition, used for faster lookups.
+- `starred`: whether the segment is starred by its creator.
+- `starred_by`: a list of user logins who have starred this segment.
 
 <a name="other-data-user"></a>
 ### Users

--- a/docs/5.x/database-schema.md
+++ b/docs/5.x/database-schema.md
@@ -238,7 +238,6 @@ Conversions are stored in the `log_conversion` table and consist of the followin
 - `server_time`: the datetime of the conversion in the UTC timezone
 - `idaction_url`: the ID of the URL action type of the visit action that caused this conversion
 - `idlink_va`: the ID of the specific visit action that resulted in this conversion
-- `referer_visit_server_date`: <!-- TODO: what is this? tied to _refts query parameter -->
 - `url`: the URL that caused this conversion to be tracked
 - `idgoal`: the ID of the goal this conversion is for
 - `idorder`: if this conversion is for an ecommerce order or abandoned cart, this will be the order's ID

--- a/docs/5.x/database-schema.md
+++ b/docs/5.x/database-schema.md
@@ -458,7 +458,7 @@ Piwik defines 4 types of permissions:
 The following information is stored in the `access` table:
 
 - `login`: the user's login handle.
-- `access`: the user's permission on this website (`view` or `admin`).
+- `access`: the user's permission on this website (`view`, `write`, or `admin`).
 - `idsite`: the website ID for which the user's `login` will have the specified `access`.
 
 Note that the Super User permissions are stored in the `user` table in the column `superuser_access`.

--- a/docs/5.x/database-schema.md
+++ b/docs/5.x/database-schema.md
@@ -422,14 +422,23 @@ User entities describe each Piwik user. They are persisted in the `user` table.
 The following information is stored in a user entity:
 
 - `login`: the user's login handle.
-- `password'`: a hash of the user's password.
-- `alias`: the user's alias if any. This value is displayed instead of the login handle when addressing the user in the UI.
+- `password`: a hash of the user's password.
 - `email`: the user's email address.
-- `twofactor_secret`: the 2FA secret
-- `token_auth`: a user's token auth.
+- `twofactor_secret`: the 2FA secret.
 - `superuser_access`: whether the user has Super User permission.
 - `date_registered`: the date the user data was persisted.
 - `ts_password_modified`: the date the user password was last changed.
+- `idchange_last_viewed`: the ID of the last change the user has viewed.
+- `invited_by`: the login of the user who invited this user (if any).
+- `invite_token`: token used for the invitation process.
+- `invite_link_token`: token used for the invitation link.
+- `invite_expired_at`: the date when the invitation expires.
+- `invite_accept_at`: the date when the invitation was accepted.
+- `ts_changes_shown`: the date when changes were last shown to the user.
+- `ts_last_seen`: the date when the user was last seen active.
+- `ts_inactivity_notified`: the date when the user was notified about inactivity.
+
+Note: The `alias` column was removed in Matomo 4.0. Authentication tokens are stored in a separate `user_token_auth` table.
 
 User data is read on every UI and [Reporting API](/guides/piwiks-reporting-api) request.
 


### PR DESCRIPTION
## Summary
Update database schema documentation to match the current Matomo 5.x schema, including missing columns in segment table, corrected access column descriptions, and updated user table columns.

## Changes
- docs(database-schema): add missing hash, starred, starred_by columns to segment table
- docs(database-schema): add write permission to access column description
- docs(database-schema): remove obsolete referer_visit_server_date from log_conversion
- docs(database-schema): update user table columns to match current schema

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules