### PR TITLE
Fix dependency injection docs: correct namespaces, methods, and examples

### DIFF
--- a/docs/5.x/dependency-injection.md
+++ b/docs/5.x/dependency-injection.md
@@ -150,7 +150,7 @@ We configure to inject the `log.format` entry in the constructor:
 ```php
 return array(
     'Piwik\Log\Formatter\LineMessageFormatter' => Piwik\DI::autowire()
-        ->constructor(Piwik\DI::link('log.format')),
+        ->constructor(Piwik\DI::get('log.format')),
 );
 ```
 
@@ -159,7 +159,7 @@ or
 ```php
 return array(
     'Piwik\Log\Formatter\LineMessageFormatter' => Piwik\DI::autowire()
-        ->constructorParameter('logFormat', Piwik\DI::link('log.format')),
+        ->constructorParameter('logFormat', Piwik\DI::get('log.format')),
 );
 ```
 

--- a/docs/5.x/dependency-injection.md
+++ b/docs/5.x/dependency-injection.md
@@ -18,7 +18,7 @@ and testing your code more easily.
 ## Loading a class through dependency injection
 
 Plugin developers can take advantage of constructor injection in most API classes in Matomo. This works for example for 
-controllers, APIs, widgets, menus, tasks, commands etc. Matomo will automatically create the needed instances and pass 
+controllers, APIs, widgets, menus, tasks etc. Matomo will automatically create the needed instances and pass 
 it to your constructor.
 
 For example if you want an instance of a logger and translator, simply define them in the constructor. It automatically 

--- a/docs/5.x/dependency-injection.md
+++ b/docs/5.x/dependency-injection.md
@@ -138,7 +138,7 @@ Given that you have the following class:
 ```php
 class LineMessageFormatter
 {
-    public function __construct($logFormat)
+    public function __construct($logMessageFormat)
     {
         // ...
     }
@@ -159,7 +159,7 @@ or
 ```php
 return array(
     'Piwik\Plugins\Monolog\Formatter\LineMessageFormatter' => Piwik\DI::autowire()
-        ->constructorParameter('logFormat', Piwik\DI::get('log.format')),
+        ->constructorParameter('logMessageFormat', Piwik\DI::get('log.format')),
 );
 ```
 

--- a/docs/5.x/dependency-injection.md
+++ b/docs/5.x/dependency-injection.md
@@ -109,7 +109,7 @@ The container includes the following configuration files in the order listed:
 
 When developing a plugin, you can supply DI config with your plugin in one of the files listed above to either configure your plugin or customize Matomo.
 
-The syntax used in those files is described in [PHP-DI's documentation](http://php-di.org/doc/definition.html). Below are examples of the most common use cases.
+The syntax used in those files is described in [PHP-DI's documentation](https://php-di.org/doc/definition.html). Below are examples of the most common use cases.
 
 ### Binding an interface to a class
 

--- a/docs/5.x/dependency-injection.md
+++ b/docs/5.x/dependency-injection.md
@@ -125,7 +125,7 @@ This will automatically create an instance of the `LoaderCache` whenever the `Lo
 
 ```php
 return array(
-    'log.format' => '%level% %tag%[%datetime%] %message%'
+    'log.short.format' => '%level% %tag%[%datetime%] %message%'
 );
 ```
 
@@ -145,12 +145,12 @@ class LineMessageFormatter
 }
 ```
 
-We configure to inject the `log.format` entry in the constructor:
+We configure to inject the `log.short.format` entry in the constructor:
 
 ```php
 return array(
     'Piwik\Plugins\Monolog\Formatter\LineMessageFormatter' => Piwik\DI::autowire()
-        ->constructor(Piwik\DI::get('log.format')),
+        ->constructor(Piwik\DI::get('log.short.format')),
 );
 ```
 
@@ -159,7 +159,7 @@ or
 ```php
 return array(
     'Piwik\Plugins\Monolog\Formatter\LineMessageFormatter' => Piwik\DI::autowire()
-        ->constructorParameter('logMessageFormat', Piwik\DI::get('log.format')),
+        ->constructorParameter('logMessageFormat', Piwik\DI::get('log.short.format')),
 );
 ```
 

--- a/docs/5.x/dependency-injection.md
+++ b/docs/5.x/dependency-injection.md
@@ -181,11 +181,11 @@ using references to make manipulation possible it's required to wrap the event l
 
 ```php
 return [
-    'observers.global' => [
+    'observers.global' => Piwik\DI::add([
         ['AssetManager.getStylesheetFiles', Piwik\DI::value(function (&$stylesheets) {
             $stylesheets[] = 'my\custom.css';
         })],
-    ],
+    ]),
 ];
 ```
 

--- a/docs/5.x/dependency-injection.md
+++ b/docs/5.x/dependency-injection.md
@@ -149,7 +149,7 @@ We configure to inject the `log.format` entry in the constructor:
 
 ```php
 return array(
-    'Piwik\Log\Formatter\LineMessageFormatter' => Piwik\DI::autowire()
+    'Piwik\Plugins\Monolog\Formatter\LineMessageFormatter' => Piwik\DI::autowire()
         ->constructor(Piwik\DI::get('log.format')),
 );
 ```
@@ -158,7 +158,7 @@ or
 
 ```php
 return array(
-    'Piwik\Log\Formatter\LineMessageFormatter' => Piwik\DI::autowire()
+    'Piwik\Plugins\Monolog\Formatter\LineMessageFormatter' => Piwik\DI::autowire()
         ->constructorParameter('logFormat', Piwik\DI::get('log.format')),
 );
 ```


### PR DESCRIPTION
## Summary
Fix multiple inaccuracies in DI documentation including wrong config key names, incorrect namespaces, outdated DI helper methods, and broken examples.

## Changes
- docs(dependency-injection): replace log.format with log.short.format
- docs(dependency-injection): update PHP-DI docs URL from http to https
- docs(dependency-injection): wrap observers.global example with Piwik\DI::add()
- docs(dependency-injection): fix constructor parameter name logFormat to logMessageFormat
- docs(dependency-injection): fix LineMessageFormatter namespace
- docs(dependency-injection): remove commands from constructor injection list
- docs(dependency-injection): replace Piwik\DI::link() with Piwik\DI::get()

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules