### PR TITLE
Fix getting started docs: correct PHP version and update URLs

### DIFF
--- a/docs/5.x/getting-started-part-1.md
+++ b/docs/5.x/getting-started-part-1.md
@@ -57,7 +57,7 @@ If you can't think of an idea for a plugin, you can check the *[New plugin](http
 Before we start extending Matomo, let's make sure you have the tools needed. You will need the following:
 
 - **A PHP IDE or a text editor.** We recommend using [PhpStorm](https://www.jetbrains.com/phpstorm/), a powerful IDE built specifically for developing in PHP.
-- **A webserver,** such as [Apache](https://www.apache.org/) or [Nginx](https://nginx.org/). You can also use [PHP's built-in webserver](https://secure.php.net/manual/en/features.commandline.webserver.php) on your development machine if you have PHP 7.2.5 or higher installed.
+- **A webserver,** such as [Apache](https://www.apache.org/) or [Nginx](https://nginx.org/). You can also use [PHP's built-in webserver](https://www.php.net/manual/en/features.commandline.webserver.php) on your development machine if you have PHP 7.2.5 or higher installed.
 - **A MySQL database**
 - **[git](https://git-scm.com/)** so you can work with the latest Matomo source code.
 - **[Composer](https://getcomposer.org/)** so you can install the PHP libraries needed by Matomo.
@@ -114,7 +114,7 @@ Next, we will install all the libraries that Matomo needs using Composer.
 
 Now that you've got a copy of Matomo, you'll need to point your web server to it. If you use Apache or Nginx, the specific instructions for configuring your web server depend on the web server itself.
 
-If your PHP version is 7.2.5 or greater, you can also use [PHP's built-in web server](https://secure.php.net/manual/en/features.commandline.webserver.php) which requires no installation. Simply run the following command:
+If your PHP version is 7.2.5 or greater, you can also use [PHP's built-in web server](https://www.php.net/manual/en/features.commandline.webserver.php) which requires no installation. Simply run the following command:
 
     $ php -S 0.0.0.0:8000
 

--- a/docs/5.x/getting-started-part-1.md
+++ b/docs/5.x/getting-started-part-1.md
@@ -57,7 +57,7 @@ If you can't think of an idea for a plugin, you can check the *[New plugin](http
 Before we start extending Matomo, let's make sure you have the tools needed. You will need the following:
 
 - **A PHP IDE or a text editor.** We recommend using [PhpStorm](https://www.jetbrains.com/phpstorm/), a powerful IDE built specifically for developing in PHP.
-- **A webserver,** such as [Apache](https://www.apache.org/) or [Nginx](https://nginx.org/). You can also use [PHP's built-in webserver](https://secure.php.net/manual/en/features.commandline.webserver.php) on your development machine if you have PHP 5.4 or higher installed.
+- **A webserver,** such as [Apache](https://www.apache.org/) or [Nginx](https://nginx.org/). You can also use [PHP's built-in webserver](https://secure.php.net/manual/en/features.commandline.webserver.php) on your development machine if you have PHP 7.2.5 or higher installed.
 - **A MySQL database**
 - **[git](https://git-scm.com/)** so you can work with the latest Matomo source code.
 - **[Composer](https://getcomposer.org/)** so you can install the PHP libraries needed by Matomo.
@@ -114,7 +114,7 @@ Next, we will install all the libraries that Matomo needs using Composer.
 
 Now that you've got a copy of Matomo, you'll need to point your web server to it. If you use Apache or Nginx, the specific instructions for configuring your web server depend on the web server itself.
 
-If your PHP version is greater than 5.4, you can also use [PHP's built-in web server](https://secure.php.net/manual/en/features.commandline.webserver.php) which requires no installation. Simply run the following command:
+If your PHP version is 7.2.5 or greater, you can also use [PHP's built-in web server](https://secure.php.net/manual/en/features.commandline.webserver.php) which requires no installation. Simply run the following command:
 
     $ php -S 0.0.0.0:8000
 

--- a/docs/5.x/getting-started-part-1.md
+++ b/docs/5.x/getting-started-part-1.md
@@ -11,12 +11,12 @@ TODO: (stuff that needs to go in SOME guide)
 
 ## About this guide
 
-If you're a Piwik user and need Piwik to do something it doesn't do; or maybe you use another web app and want to integrate it with this amazing analytics software you've heard so much about (Piwik, naturally) — well, you've come to the right place!
+If you're a Matomo user and need Matomo to do something it doesn't do; or maybe you use another web app and want to integrate it with this amazing analytics software you've heard so much about (Matomo, naturally) — well, you've come to the right place!
 
 This guide will show you:
 
 - **how to get your development environment set up,**
-- **how to create a new Piwik Plugin,**
+- **how to create a new Matomo Plugin,**
 - **and where to go next to continue building your extension.**
 
 **Guide assumptions**
@@ -25,15 +25,15 @@ This guide assumes that you can code in PHP and can set up your own local webser
 
 There are many resources on the internet to help you learn PHP. We recommend reading [these tutorials](https://phptherightway.com/). To learn how to set up a web server read the documentation for your preferred web server software (for example [Apache](https://www.apache.org/) or [Nginx](https://nginx.org/)).
 
-## Piwik Plugins and Piwik Core
+## Matomo Plugins and Matomo Core
 
-All the functionality you see when you use Piwik is provided by **_Piwik Plugins_**. The core of Piwik (termed _**Piwik Core**_) only contains tools for those plugins.
+All the functionality you see when you use Matomo is provided by **_Matomo Plugins_**. The core of Matomo (termed _**Matomo Core**_) only contains tools for those plugins.
 
-If you want to add more functionality to Piwik, create your own plugin then distribute it on the [Piwik Marketplace](https://plugins.matomo.org) so that others can use it.
+If you want to add more functionality to Matomo, create your own plugin then distribute it on the [Matomo Marketplace](https://plugins.matomo.org) so that others can use it.
 
-_Note: If you want to integrate another piece of software with Piwik and you only need to know how to track visits or how to retrieve reports, read more about [Integrating Piwik in your application](/integration)._
+_Note: If you want to integrate another piece of software with Matomo and you only need to know how to track visits or how to retrieve reports, read more about [Integrating Matomo in your application](/integration)._
 
-### What is possible with Piwik plugins?
+### What is possible with Matomo plugins?
 
 You can accomplish the following by creating a plugin:
 
@@ -42,25 +42,25 @@ You can accomplish the following by creating a plugin:
 - show existing reports in a new way
 - send scheduled reports through new mediums or in new formats
 
-These are only a few of the possibilities — it is not possible to categorize all the existing plugins' functionality simply because of the vast differences in their use cases. For example, the [Annotations](https://matomo.org/docs/annotations/) plugin lets users add notes for dates without requiring modifications to **Piwik Core**. The DBStats plugin will show users statistics about their MySQL database. The [Dashboard](https://matomo.org/docs/matomo-tour/#dashboard-widgets) plugin provides a configurable way to view multiple reports at once.
+These are only a few of the possibilities — it is not possible to categorize all the existing plugins' functionality simply because of the vast differences in their use cases. For example, the [Annotations](https://matomo.org/docs/annotations/) plugin lets users add notes for dates without requiring modifications to **Matomo Core**. The DBStats plugin will show users statistics about their MySQL database. The [Dashboard](https://matomo.org/docs/matomo-tour/#dashboard-widgets) plugin provides a configurable way to view multiple reports at once.
 
-**Whatever ideas your imagination cooks up, we think you can implement them with Piwik.**
+**Whatever ideas your imagination cooks up, we think you can implement them with Matomo.**
 
 <div markdown="1" class="alert alert-info">
 If you can't think of an idea for a plugin, you can check the *[New plugin](https://github.com/matomo-org/matomo/labels/c%3A%20New%20plugin)* label on GitHub or [adopt an existing, not maintained plugin](https://forum.matomo.org/t/adopt-a-plugin-dog/26869).
 </div>
 
-## Getting setup to extend Piwik
+## Getting setup to extend Matomo
 
 ### Get the appropriate tools
 
-Before we start extending Piwik, let's make sure you have the tools needed. You will need the following:
+Before we start extending Matomo, let's make sure you have the tools needed. You will need the following:
 
 - **A PHP IDE or a text editor.** We recommend using [PhpStorm](https://www.jetbrains.com/phpstorm/), a powerful IDE built specifically for developing in PHP.
 - **A webserver,** such as [Apache](https://www.apache.org/) or [Nginx](https://nginx.org/). You can also use [PHP's built-in webserver](https://secure.php.net/manual/en/features.commandline.webserver.php) on your development machine if you have PHP 5.4 or higher installed.
 - **A MySQL database**
-- **[git](https://git-scm.com/)** so you can work with the latest Piwik source code.
-- **[Composer](https://getcomposer.org/)** so you can install the PHP libraries needed by Piwik.
+- **[git](https://git-scm.com/)** so you can work with the latest Matomo source code.
+- **[Composer](https://getcomposer.org/)** so you can install the PHP libraries needed by Matomo.
 - **A browser,** such as [Firefox](https://www.mozilla.org/en-US/firefox/new/) or [Chrome](https://www.google.com/chrome). Ok, you've probably got this.
 
 The following tools aren't required for this guide, but you may find them useful as you create your plugin:
@@ -98,11 +98,11 @@ Open a terminal, `cd` into the directory where you want to install Matomo, and t
 
 ### Get & install Composer
 
-Next, we will install all the libraries that Piwik needs using Composer.
+Next, we will install all the libraries that Matomo needs using Composer.
 
  * Follow the [download instructions for Composer](https://getcomposer.org/download/) in order to get composer on your machine
 
- * Then run this command to download all PHP packages that Piwik requires:
+ * Then run this command to download all PHP packages that Matomo requires:
 
         $ php composer.phar install
 
@@ -112,17 +112,17 @@ Next, we will install all the libraries that Piwik needs using Composer.
 
 ### Get a web server
 
-Now that you've got a copy of Piwik, you'll need to point your web server to it. If you use Apache or Nginx, the specific instructions for configuring your web server depend on the web server itself.
+Now that you've got a copy of Matomo, you'll need to point your web server to it. If you use Apache or Nginx, the specific instructions for configuring your web server depend on the web server itself.
 
 If your PHP version is greater than 5.4, you can also use [PHP's built-in web server](https://secure.php.net/manual/en/features.commandline.webserver.php) which requires no installation. Simply run the following command:
 
     $ php -S 0.0.0.0:8000
 
-Piwik should now be available at [http://localhost:8000/](http://localhost:8000/). To stop the web server, just hit `Ctrl+C`. Remember that PHP's built in web server is only suitable for development. It should **never** be used in production.
+Matomo should now be available at [http://localhost:8000/](http://localhost:8000/). To stop the web server, just hit `Ctrl+C`. Remember that PHP's built in web server is only suitable for development. It should **never** be used in production.
 
 ### Install MySQL and create a database
 
-When you install Piwik, at the database creation step, you will need to specify your database user.
+When you install Matomo, at the database creation step, you will need to specify your database user.
 
 [-> Click here to see how to create a new user in MySQL](https://matomo.org/faq/how-to-install/faq_23484/).
 
@@ -137,12 +137,12 @@ If you are developing with Matomo then we usually recommend using the "root" dat
 
 ### Install Matomo
 
-Once Piwik is running, open it in your browser and follow the instructions to complete the installation.
+Once Matomo is running, open it in your browser and follow the instructions to complete the installation.
 
 
 #### Adding anonymous access to your reports
 
-Before we finish, we're going to allow anyone to view reports on your new Piwik environment. Open the Administration dashboard (click on the cog icon), go to _System > Users_ page and choose **View** in the **Role** column for the **anonymous** user:
+Before we finish, we're going to allow anyone to view reports on your new Matomo environment. Open the Administration dashboard (click on the cog icon), go to _System > Users_ page and choose **View** in the **Role** column for the **anonymous** user:
 
 <img src="/img/getting_started_users_manager_anonymous.png"/>
 
@@ -151,16 +151,16 @@ This will make it possible to view raw report data without having to supply a **
 
 ### Enable Development mode
 
-After installing Piwik, we're going to change some of Piwik's INI configuration to make development easier and to make sure all changes take effect immediately. Piwik comes with a handy command-line tool that will do this work for you. In the root directory of your Piwik install, run the following command to enable development mode:
+After installing Matomo, we're going to change some of Matomo's INI configuration to make development easier and to make sure all changes take effect immediately. Matomo comes with a handy command-line tool that will do this work for you. In the root directory of your Matomo install, run the following command to enable development mode:
 
     ./console development:enable
 
 
-### Add some test tracking data in your Piwik
+### Add some test tracking data in your Matomo
 
 You're now ready to create your first plugin, but before we do that, let's add some test data for you to play with.
 
-In your browser, load Piwik and navigate to  _Platform > Marketplace_ on the Administration dashboard. Look for the "Visitor Generator" plugin and enable it. Then on the admin menu to the left, click on _Development > Visitor Generator_.
+In your browser, load Matomo and navigate to  _Platform > Marketplace_ on the Administration dashboard. Look for the "Visitor Generator" plugin and enable it. Then on the admin menu to the left, click on _Development > Visitor Generator_.
 
 On this page you'll see a form where you can select a site and enter a number of days to generate data for:
 
@@ -210,7 +210,7 @@ This will create a new plugin named **MyPlugin**.
 You can use any name for your plugin, but this guide will assume you've created one named **MyPlugin**. If you use a different name, make sure to change `MyPlugin` to the name you used when copying the code in this guide.
 </div>
 
-In your browser load Piwik and navigate to *Administration > Plugins*. Look for your plugin in the list of plugins, you should see it disabled:
+In your browser load Matomo and navigate to *Administration > Plugins*. Look for your plugin in the list of plugins, you should see it disabled:
 
 <img src="/img/disabled_my_plugin.png"/>
 
@@ -222,10 +222,10 @@ To enable it, either do it through the web interface or use the command line:
 
 The command-line tool will create a new directory for your plugin (in the **plugins** sub-directory) and fill it with some files and folders. Here's what these files and folders are for:
 
-- `MyPlugin.php`: Contains your plugin's descriptor class. This class contains metadata about your plugin and a list of event handlers for [Piwik events](/guides/events).
+- `MyPlugin.php`: Contains your plugin's descriptor class. This class contains metadata about your plugin and a list of event handlers for [Matomo events](/guides/events).
 - `plugin.json`: Contains plugin metadata such as the name, description, version, etc.
 - `README.md`: A dummy README file for your plugin.
-- `screenshots/`: Place screenshots of your plugin in this folder in case you want to [distribute it on the Piwik Marketplace](https://developer.matomo.org/guides/distributing-your-plugin).
+- `screenshots/`: Place screenshots of your plugin in this folder in case you want to [distribute it on the Matomo Marketplace](https://developer.matomo.org/guides/distributing-your-plugin).
 
 ## Troubleshooting Local Development
 
@@ -237,10 +237,10 @@ The command-line tool will create a new directory for your plugin (in the **plug
 Ok! You've set up your development environment and created your plugin! Now all you have to do is make it do what you want. The bad news is that this is the hard part. The good news is that we've written a bunch of other guides to help you shorten the learning curve.
 
 - If you're interested in **creating new analytics reports**, you may want to read about [Custom Reports](/guides/custom-reports) and [Visualizing Report Data](/guides/visualizing-report-data) guides.
-- If you're interested in **changing the look and feel of Piwik**, read the [Theming](/guides/theming) guide.
-- If you're interested in **integrating Piwik with another technology**, you might want to read the [Tracking guides](/guides/tracking-introduction) to learn how to use the Tracking API.
+- If you're interested in **changing the look and feel of Matomo**, read the [Theming](/guides/theming) guide.
+- If you're interested in **integrating Matomo with another technology**, you might want to read the [Tracking guides](/guides/tracking-introduction) to learn how to use the Tracking API.
 - If you want to **use automated testing to ensure your plugin works**, read the [Automated Tests](/guides/tests) guide.
 
 And **make sure to read our security guide, [Security in Piwik](/guides/security-in-piwik)**! We have very high security standards that your plugin or contribution **must** respect.
 
-When you've completed your plugin, you can read the [Distributing your plugin](/guides/distributing-your-plugin) guide to learn how to **share your plugin with other Piwik users**.
+When you've completed your plugin, you can read the [Distributing your plugin](/guides/distributing-your-plugin) guide to learn how to **share your plugin with other Matomo users**.


### PR DESCRIPTION
## Summary
Fix minimum PHP version from 5.4 to 7.2.5, update stale secure.php.net URLs to www.php.net, and replace outdated Piwik branding with Matomo.

## Changes
- docs(getting-started-part-1): update secure.php.net URLs to www.php.net
- docs(develop-getting-started): fix minimum PHP version from 5.4 to 7.2.5
- docs(develop-getting-started): replace outdated Piwik branding with Matomo

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules