### PR TITLE
Fix events docs: correct variable name typo and update branding

### DIFF
--- a/docs/5.x/events.md
+++ b/docs/5.x/events.md
@@ -138,6 +138,6 @@ Event handlers can read these optional values as follows:
 public function handleMyEventInATemplate(&$outString, $usefulVariable1, $usefulVariable2)
 {
     $outString .= '<h1>This text was injected!</h1>';
-    $outString .= $usefulVariable . ' - ' . $usefulVariable2;
+    $outString .= $usefulVariable1 . ' - ' . $usefulVariable2;
 }
 ```

--- a/docs/5.x/events.md
+++ b/docs/5.x/events.md
@@ -3,17 +3,17 @@ category: Develop
 ---
 # Events
 
-Piwik's event system works like any other event system:
+Matomo's event system works like any other event system:
 
 - **events can be posted**
 - **events can be handled** by registering code to be executed when it is posted
 
-Piwik Core will post events all along the code execution so that plugins can register to them. 
+Matomo Core will post events all along the code execution so that plugins can register to them. 
 Plugins can also post and handle their own custom events (or events of other plugins).
 
 ## Complete list of events
 
-The complete list of events posted by Piwik Core is [here](/api-reference/events).
+The complete list of events posted by Matomo Core is [here](/api-reference/events).
 
 
 ## Handling events


### PR DESCRIPTION
## Summary
Fix typo in event handler example where variable name was inconsistent, and replace outdated Piwik branding with Matomo in prose text.

## Changes
- Fix typo: $usefulVariable -> $usefulVariable1 in event handler example
- Replace outdated "Piwik" branding with "Matomo" in prose text

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules