### PR TITLE
Fix form analytics and heatmap docs: correct defaults and branding

### DIFF
--- a/docs/5.x/form-analytics.md
+++ b/docs/5.x/form-analytics.md
@@ -7,10 +7,10 @@ subGuides:
 ---
 # Form Analytics
 
-This section contains guides that will help you track your online web forms using Piwik. 
+This section contains guides that will help you track your online web forms using Matomo. 
 
-[Form Analytics](https://www.form-analytics.net) is a plugin for Piwik that can be purchased 
-on the [Piwik Marketplace](https://plugins.matomo.org/premium) soon. It adds over 50 new metrics to your Piwik, several 
+[Form Analytics](https://www.form-analytics.net) is a plugin for Matomo that can be purchased 
+on the [Matomo Marketplace](https://plugins.matomo.org/FormAnalytics). It adds over 50 new metrics to your Matomo, several 
  new segments, more than 10 new reports, real time reports, and widgets that you can add to your dashboard. This way
   you can understand much better how your visitors use your web and application forms to increase your conversions.
-Form Analytics is developed by [InnoCraft](https://www.innocraft.com), the makers of Piwik. 
+Form Analytics is developed by [InnoCraft](https://www.innocraft.com), the makers of Matomo. 

--- a/docs/5.x/form-analytics/reference.md
+++ b/docs/5.x/form-analytics/reference.md
@@ -12,13 +12,13 @@ You may also be interested in the Form Analytics [Reporting HTTP API Reference](
 
 In the `matomo.js` tracker we differentiate between two kind of methods:
 
-* Calling a **tracker instance method** affects only a specific Piwik tracker instance. In the docs you can 
+* Calling a **tracker instance method** affects only a specific Matomo tracker instance. In the docs you can 
   identify a tracker method when the method name contains a single dot (`.`), for example 
   `FormAnalytics.disable`.
 * Calling a **static method** affects all created tracker instances. In the docs you can identify a static method when 
   the method name contains `::`, for example `FormAnalytics::scanForForms`.
 
-In most cases only one Piwik tracker will be used so the only difference is how you call that method:
+In most cases only one Matomo tracker will be used so the only difference is how you call that method:
 
 * Tracker methods are called via `_paq.push(['FormAnalytics.$methodName']);` or on a tracker instance directly eg. 
   `Matomo.getAsyncTracker().FormAnalytics.$methodName()`.
@@ -37,8 +37,8 @@ window.matomoFormAnalyticsAsyncInit = function () {
 ## Static methods
 
 ### `scanForForms(documentOrHTMLElementToScanForForms)`.
-By default, Piwik detects all forms on your website automatically. If you modify the DOM after the page was loaded (for 
-example in a single-page web application), you may need to call this method to make sure Piwik finds all your forms. 
+By default, Matomo detects all forms on your website automatically. If you modify the DOM after the page was loaded (for 
+example in a single-page web application), you may need to call this method to make sure Matomo finds all your forms. 
 When you call this method, the Form Analytics tracker will search the DOM for new forms and start the tracking 
 of those forms. As a parameter, you can optionally pass an `HTMLElement` if only a part of the DOM should be searched for 
 new form. This is especially useful for one page web applications. If no such parameter is given, the entire DOM will 
@@ -57,13 +57,13 @@ Matomo.FormAnalytics.scanForForms(document.getElementById('test'));
 
 This method is almost the same as `scanForForms`. However, `scanForForms` will detect only forms that are either a
 `form` element, a `data-matomo-form` attribute, or a `data-piwik-form` attribute. If neither of this is the case for one of your forms, you can use 
-this method to make sure Piwik will track data for all form fields within this element. It is recommended to set a 
-`data-matomo-name` or a `data-piwik-name` attribute to let Piwik know the name of your form.
+this method to make sure Matomo will track data for all form fields within this element. It is recommended to set a 
+`data-matomo-name` or a `data-piwik-name` attribute to let Matomo know the name of your form.
 
 ### `trackFormSubmit(formElement)`
 
-By default, Piwik will automatically listen to the form submit event. If you are not using a `form` element, you may 
- need to let Piwik know when the form was submitted by calling this method:
+By default, Matomo will automatically listen to the form submit event. If you are not using a `form` element, you may 
+ need to let Matomo know when the form was submitted by calling this method:
  
 ```html
 <div data-matomo-form id="login"></div>
@@ -72,8 +72,8 @@ By default, Piwik will automatically listen to the form submit event. If you are
 
 ### `trackFormConversion(nodeOrFormName, formId)`
 
-Piwik differentiates between form submits and form conversions. A form may be submitted several times before it is converted
-as a visitor may have to correct form validation errors. To track a form conversion, you can configure one or several pages in the Piwik administration and as soon as a visitor views any of these
+Matomo differentiates between form submits and form conversions. A form may be submitted several times before it is converted
+as a visitor may have to correct form validation errors. To track a form conversion, you can configure one or several pages in the Matomo administration and as soon as a visitor views any of these
  configured pages, a conversion will be tracked. If you do not redirect a user to a specific page after submitting a 
  form successfully, you can trigger a form conversion manually by calling this method.
  
@@ -92,7 +92,7 @@ _paq.push(['FormAnalytics::trackFormConversion', 'cloudlogin', 'login']);
 ### `disableFormAnalytics()`
 
 Allows you to completely disable the tracking of any forms. This is useful if you for example manage multiple websites
-in your Piwik and there are some sites where you do not want to track any forms. If called early in your tracking code
+in your Matomo and there are some sites where you do not want to track any forms. If called early in your tracking code
  or via the `matomoFormAnalyticsAsyncInit` method, it will not even search for forms on your web page.
 
 ### `enableFormAnalytics()`
@@ -113,14 +113,14 @@ enabled in production.
 ### `setMatomoTrackers()`
 
 Allows you to set the tracker instances the tracker should use when tracking your forms. Can be either
- a single tracker instance, or an array of Piwik tracker instances. This is useful when you are working with multiple Piwik
+ a single tracker instance, or an array of Matomo tracker instances. This is useful when you are working with multiple Matomo
  tracker instances using `Matomo.getTracker` instead of `Matomo.addTracker`. 
  
 ### `setTrackingTimer(delayInMilliSeconds)`
 
-By default, the tracker sends a tracking request to your Piwik 1.5 seconds after a user interacted with a form. If a
-user interacts several times with your forms during those 1.5 seconds, the tracking request will be delayed by another 
-1.5 seconds. This way, Piwik can group several form tracking requests into one request when a user is heavily interacting with your form.
+By default, the tracker sends a tracking request to your Matomo 30 seconds after a user interacted with a form. If a
+user interacts several times with your forms during those 30 seconds, the tracking request will be delayed by another 
+30 seconds. This way, Matomo can group several form tracking requests into one request when a user is heavily interacting with your form.
 If you want to send this update more or less frequently, you can set a different delay using this method. It is usually not 
 needed to call this method unless you want to reduce the number of requests sent to your server.
 
@@ -128,16 +128,16 @@ needed to call this method unless you want to reduce the number of requests sent
 
 ### `disable()`
 
-Disables the tracking of any forms to this Piwik instance. If you have only one tracker on your website, it is the same
- as calling `disableFormAnalytics()`. If you have multiple Piwik trackers on your web page, you can disable the tracking
- for a specific Piwik instances by calling this method.
+Disables the tracking of any forms to this Matomo instance. If you have only one tracker on your website, it is the same
+ as calling `disableFormAnalytics()`. If you have multiple Matomo trackers on your web page, you can disable the tracking
+ for a specific Matomo instances by calling this method.
 
 Example:
 
 ```js
 _paq.push(['FormAnalytics.disable']); 
 
-// or if you are using multiple Piwik trackers and only want to disable it for a specific tracker:
+// or if you are using multiple Matomo trackers and only want to disable it for a specific tracker:
 var tracker = Matomo.getTracker(matomoUrl, matomoSiteId);
 tracker.FormAnalytics.disable();
 ```

--- a/docs/5.x/form-analytics/setup.md
+++ b/docs/5.x/form-analytics/setup.md
@@ -8,17 +8,17 @@ In this guide you will learn how to get [Form Analytics](https://www.form-analyt
 
 ## Embedding the Form Analytics JavaScript Tracker
 
-If you have already embedded the [Piwik JavaScript Tracking Code](/guides/tracking-javascript-guide) into your website,
+If you have already embedded the [Matomo JavaScript Tracking Code](/guides/tracking-javascript-guide) into your website,
 the Form Analytics will automatically start tracking the usage of your web forms. 
 
-The tracker code for forms is automatically added into your Matomo JavaScript tracker file `/matomo.js` as long as the file `matomo.js` in your Piwik directory is writable by the webserver/PHP.
+The tracker code for forms is automatically added into your Matomo JavaScript tracker file `/matomo.js` as long as the file `matomo.js` in your Matomo directory is writable by the webserver/PHP.
  
 To check whether this works by default for you, login into Matomo as a Super User, go to Administration, and open the "System Check" report. 
 If the System Check displays a warning for "Writable Matomo.js" then [learn below how to solve this](#when-the-matomojs-in-your-piwik-directory-file-is-not-writable).
 
 ## Tracking Forms
 
-Piwik detects and starts the tracking of your forms automatically if they have set a form `name` or a form `id` attribute like this:
+Matomo detects and starts the tracking of your forms automatically if they have set a form `name` or a form `id` attribute like this:
 
 ```html
 <form name="cloud_login">...</form>
@@ -44,14 +44,14 @@ Similarly you can define a readable name for your fields like this:
 <input data-matomo-name="username" type="text">
 ```
 
-Note that in Piwik Form Analytics itself you can give a readable name to any form or any field. If your form has for example a field named "input_4",
-you can map this field name to a human readable name like "Username" directly in the Piwik user interface. 
+Note that in Matomo Form Analytics itself you can give a readable name to any form or any field. If your form has for example a field named "input_4",
+you can map this field name to a human readable name like "Username" directly in the Matomo user interface. 
 You don't need to set a `data-matomo-name` or a `data-piwik-name` in this case.
 
 ## Custom form elements
 
 If you do not use a `<form>` element to mark your forms, you can specify a `data-matomo-form` (recommended) or a `data-piwik-form` attribute on any element 
-to let Piwik know that this element contains a form. Piwik will then discover this form and all fields automatically.
+to let Matomo know that this element contains a form. Matomo will then discover this form and all fields automatically.
 
 ```html
 <div data-matomo-form data-matomo-name="cloud_login">
@@ -71,16 +71,16 @@ If you do not want a form to be tracked, you can specify a `data-matomo-ignore` 
 <form name="cloud_signup" data-matomo-ignore></form>
 ```
 
-If set, it will not even send any tracking requests for this form to your Piwik. This is useful if you want to exclude
+If set, it will not even send any tracking requests for this form to your Matomo. This is useful if you want to exclude
 for example forms that are shown on each page like a search or a newsletter sign up form.
 
-## When the `matomo.js` in your Piwik directory file is not writable
+## When the `matomo.js` in your Matomo directory file is not writable
  
-When your Settings > System Check reports that "The Piwik JavaScript tracker file `matomo.js` is not writable 
+When your Settings > System Check reports that "The Matomo JavaScript tracker file `matomo.js` is not writable 
 which means other plugins cannot extend the JavaScript tracker." then you have two options to solve this issue:
 
-1. Make the `matomo.js` file writable, for example by executing `chmod a+w piwik.js` or `chown $phpuser piwik.js` (replace `$phpuser` with actual username) in your Piwik directory. 
-We recommend running the [Piwik console](/guides/piwik-on-the-command-line) command `./console custom-piwik-js:update` after you have made the file writable.
+1. Make the `matomo.js` file writable, for example by executing `chmod a+w matomo.js` or `chown $phpuser matomo.js` (replace `$phpuser` with actual username) in your Matomo directory. 
+We recommend running the [Matomo console](/guides/piwik-on-the-command-line) command `./console custom-matomo-js:update` after you have made the file writable.
 2. or Load the FormAnalytics tracker file manually in your website by adding in all your pages ideally in the `<head>`: 
    `<script src="https://your-matomo-domain/plugins/FormAnalytics/tracker.min.js">`
 

--- a/docs/5.x/heatmap-session-recording.md
+++ b/docs/5.x/heatmap-session-recording.md
@@ -14,9 +14,9 @@ Heatmaps let you view visually all clicks, mouse moves, and scroll activities of
 
 Session recordings let you view all activities such as clicks, mouse movements, scrolls, window resizes, page changes, and form interactions of a real visitor on a certain page. You can replay these interactions in a video to see exactly how a visitor interacted with your website. This way you understand their expectations, problems they may have, usage patterns, and more.
 
-[Heatmap & Session Recording](https://www.heatmap-analytics.com) is a plugin for Piwik that can be purchased 
-on the [Piwik Marketplace](https://plugins.matomo.org/HeatmapSessionRecording).
-It is developed by [InnoCraft](https://www.innocraft.com), the makers of Piwik. 
+[Heatmap & Session Recording](https://www.heatmap-analytics.com) is a plugin for Matomo that can be purchased 
+on the [Matomo Marketplace](https://plugins.matomo.org/HeatmapSessionRecording).
+It is developed by [InnoCraft](https://www.innocraft.com), the makers of Matomo. 
 If you want to learn more about this plugin we recommend having a look at the developer guides, 
 the [Heatmap User Guide](https://matomo.org/docs/heatmaps/), [Session Recording User Guide](https://matomo.org/docs/session-recording/), and the [Heatmap & Session Recording FAQs](https://matomo.org/faq/heatmap-session-recording/).
 

--- a/docs/5.x/heatmap-session-recording/faq.md
+++ b/docs/5.x/heatmap-session-recording/faq.md
@@ -11,8 +11,8 @@ Heatmap & Session Recording has disabled the capturing of keystrokes by default 
 
 You can prevent the recording of keystrokes in two ways: 
 
-* Disable the capturing of keystrokes each time you configure a session recording in Piwik > Session Recordings > Manage (default since 3.2.0).
-* Add the following code to your Piwik tracking code to make sure to never record any entered keystrokes: ` _paq.push(['HeatmapSessionRecording::disableCaptureKeystrokes']);`
+* Disable the capturing of keystrokes each time you configure a session recording in Matomo > Session Recordings > Manage (default since 3.2.0).
+* Add the following code to your Matomo tracking code to make sure to never record any entered keystrokes: ` _paq.push(['HeatmapSessionRecording::disableCaptureKeystrokes']);`
 
 Please note that some fields that could potentially include personal information such as an email, credit card, or phone number will always be masked if detected by our tracker as such a field.
  
@@ -25,7 +25,7 @@ By default, all fields will be masked. However, there are some fields that will 
 * Any input field with the type `password`, `tel`, or `email`.
 * No value is recorded for `hidden` form elements.
 * We ignore any form field when it has an `id`, `name`, or `autocomplete` with one of these values (any dashes, underscores, or whitespace in the name are ignored): `'creditcardnumber', 'off', 'kreditkarte', 'debitcard', 'kreditkort', 'kredietkaart', ' kartakredytowa', 'cvv', 'cc', 'ccc', 'cccsc', 'cccvc', 'ccexpiry', 'ccexpyear', 'ccexpmonth', 'cccvv', 'cctype', 'cvc', 'exp', 'ccname', 'cardnumber', 'ccnumber', 'username', 'creditcard', 'name', 'fullname', 'familyname', 'firstname', 'vorname', 'nachname', 'lastname', 'nickname', 'surname', 'login', 'formlogin', 'konto', 'user', 'website', 'domain', 'gender', 'company', 'firma', 'geschlecht', 'email', 'emailaddress', 'emailadresse', 'mail', 'epos', 'ebost', 'epost', 'eposta', 'authpw', 'token_auth', 'tokenauth', 'token', 'pin', 'ibanaccountnum', 'ibanaccountnumber', 'account', 'accountnum', 'auth', 'age', 'alter', 'tel', 'city', 'cell', 'cellphone', 'bic', 'iban', 'swift', 'kontonummer', 'konto', 'kontonr', 'phone', 'mobile', 'mobiili', 'mobilne', 'handynummer', 'téléphone', 'telefono', 'ssn', 'socialsecuritynumber', 'socialsec', 'socsec', 'address', 'addressline1', 'addressline2','billingaddress', 'billingaddress1', 'billingaddress2','shippingaddress', 'shippingaddress1', 'shippingaddress2', 'vat', 'vatnumber', 'gst', 'gstnumber', 'tax', 'taxnumber', 'steuernummer', 'adresse', 'indirizzo', 'adres', 'dirección', 'osoite', 'address1', 'address2', 'address3', 'street', 'strasse', 'rue', 'via', 'ulica', 'calle', 'sokak', 'zip', 'zipcode', 'plz', 'postleitzahl', 'postalcode', 'postcode', 'dateofbirth', 'dob', 'telephone', 'telefon', 'telefonnr', 'telefonnummer', 'password', 'passwort', 'kennwort', 'wachtwoord', 'contraseña', 'passord', 'hasło', 'heslo', 'wagwoord', 'parole', 'contrasenya', 'heslo', 'clientid', 'identifier', 'id', 'consumersecret', 'webhooksecret', 'consumerkey', 'keyconsumersecret', 'keyconsumerkey', 'clientsecret', 'secret', 'secretq', 'secretquestion', 'privatekey', 'publickey', 'pw', 'pwd', 'pwrd', 'pword', 'paword', 'pasword', 'paswort', 'pass']`  
-* When a user enters between 7 and 21 digits in sequence, we assume it is a credit card number or similar and mask it. 
+* When a user enters between 7 and 24 digits in sequence, we assume it is a credit card number or similar and mask it. 
 * When a user enters an `@` symbol, we assume it is an email address and don't record it.
 * Form fields within iframes won't be recorded at all.
 
@@ -39,7 +39,7 @@ To learn more about the detection of page views, have a look at the [disableAuto
 ## I am tracking "virtual" page views, how do I make sure to record all activities within a page view?
 
 If you use the `trackPageView` method to track for example an event, a download, or to track errors, then
- Piwik assumes the user is actually viewing a new page and as a result any ongoing recording of session or heatmap activities
+ Matomo assumes the user is actually viewing a new page and as a result any ongoing recording of session or heatmap activities
 will be stopped. 
 
 To solve this issue it is recommended to either:
@@ -49,10 +49,10 @@ To solve this issue it is recommended to either:
 
 To learn more about the detection of page views, have a look at the [disableAutoDetectNewPageView() API reference](/guides/heatmap-session-recording/reference#disableautodetectnewpageview).
 
-## How do I capture heatmap and session activities for longer than 10 minutes per page view?  
+## How do I capture heatmap and session activities for longer than 15 minutes per page view?  
 
-By default, Piwik will stop the recording of new activities after 10 minutes after the last page view. You can increase this time limit by 
-calling the `setMaxCaptureTime` method. We recommend setting this value to less than 29 minutes. Piwik creates a new visit 
+By default, Matomo will stop the recording of new activities after 15 minutes after the last page view. You can increase this time limit by 
+calling the `setMaxCaptureTime` method. We recommend setting this value to less than 29 minutes. Matomo creates a new visit 
 after an inactivity of 30 minutes and there may be a risk of creating a new visit without the user being actually "active".
 
 ```js
@@ -91,15 +91,15 @@ _paq.push(['HeatmapSessionRecording::setTrigger', function (config) {
 }]);
 ```
 
-## How do I configure multiple Piwik JavaScript trackers?
+## How do I configure multiple Matomo JavaScript trackers?
 
-Piwik lets you track a website into different Piwik installations or into different Piwik websites. Learn more about 
-using [Multiple Piwik trackers on the JavaScript Tracking guide](/guides/tracking-javascript-guide#multiple-piwik-trackers).
+Matomo lets you track a website into different Matomo installations or into different Matomo websites. Learn more about 
+using [Multiple Matomo trackers on the JavaScript Tracking guide](/guides/tracking-javascript-guide#multiple-piwik-trackers).
 
 If you are using the regular `_paq.push` tracking method, everything will work out of the box when you create more trackers 
 via `_paq.push(['addTracker', url, idsite]);`
 
-Using `_paq.push` for multiple trackers is a good and simple way when you want to track the same data into different Piwik websites.
+Using `_paq.push` for multiple trackers is a good and simple way when you want to track the same data into different Matomo websites.
 
 ```js
 // configuration of first tracker
@@ -109,8 +109,8 @@ _paq.push(['setSiteId', 1]);
 _paq.push(['addTracker', 'https://example.com/matomo.php', 2]);
 ```
 
-If you are working with Piwik tracker instances because you want to configure each tracker instance differently and track
-different data into each Piwik, you may need to set the tracker instances manually:
+If you are working with Matomo tracker instances because you want to configure each tracker instance differently and track
+different data into each Matomo, you may need to set the tracker instances manually:
 
 ```js
 window.matomoAsyncInit = function () {
@@ -128,7 +128,7 @@ window.matomoAsyncInit = function () {
 }
 ```
 
-It is important to define these methods in your website before the Piwik tracker file is loaded. Otherwise, the 
+It is important to define these methods in your website before the Matomo tracker file is loaded. Otherwise, the 
 `matomoAsyncInit` method will never be called.
 
 ## How do I disable the recording of mouse and touch movements?
@@ -149,19 +149,19 @@ _paq.push(['HeatmapSessionRecording::enableRecordMovements']);
 
 ## How do I prevent the HTTP request to a configs.php on each page view?  
 
-Piwik needs to detect on each page whether a heatmap or a session recording is supposed to be tracked. To do this, Piwik
+Matomo needs to detect on each page whether a heatmap or a session recording is supposed to be tracked. To do this, Matomo
 issues an HTTP request to a file named `plugins/HeatmapSessionRecording/configs.php` on each page view. This request
 should be very fast as no database connection will be needed and the script is optimized for performance.
 
-Starting from Piwik 3.0.5, if your `matomo.js` is writable, it will execute this request on each page view only when actually a heatmap or session recording is configured to reduce server load. Find out if your `piwik.js` is writable by going to Administration, and open the "System Check" report. If the System Check displays a warning for "Writable Matomo.js" then [learn how to solve this](/guides/heatmap-session-recording/setup#when-the-matomojs-in-your-piwik-directory-file-is-not-writable).
+Starting from version 3.0.4, if your `matomo.js` is writable, it will execute this request on each page view only when actually a heatmap or session recording is configured to reduce server load. Find out if your `matomo.js` is writable by going to Administration, and open the "System Check" report. If the System Check displays a warning for "Writable Matomo.js" then [learn how to solve this](/guides/heatmap-session-recording/setup#when-the-matomojs-in-your-matomo-directory-file-is-not-writable).
  
 If you always want to prevent such a request to your server, for example to reduce the load on your server, you need to call a 
 method `HeatmapSessionRecording.addConfig()` or disable the tracking completely using `HeatmapSessionRecording.disable()`.
  
 Learn more about this in the [addConfig() API reference](/guides/heatmap-session-recording/reference#addconfig).
 
-When you track your analytics data into multiple Piwik installations, the Heatmap & Session Recording plugin may be installed
-only in one of the Piwik installation. To disable Heatmap & Session Recording for the Piwik instance that do not support this 
+When you track your analytics data into multiple Matomo installations, the Heatmap & Session Recording plugin may be installed
+only in one of the Matomo installation. To disable Heatmap & Session Recording for the Matomo instance that do not support this 
 feature, call `tracker.HeatmapSessionRecording.disable();` as follows: 
 
 ```js
@@ -169,11 +169,11 @@ feature, call `tracker.HeatmapSessionRecording.disable();` as follows:
 _paq.push(['setTrackerUrl', 'https://example.com/matomo.php']);
 _paq.push(['setSiteId', 1]);
 // configuration of second tracker which does not have the plugin installed
-_paq.push(['addTracker', 'https://not-supported-piwik.com/matomo.php', 2]);
+_paq.push(['addTracker', 'https://not-supported-matomo.com/matomo.php', 2]);
 
 window.matomoAsyncInit = function () {
-    // will never issue an HTTP request to configs.php for this Piwik instance
-    var tracker = Matomo.getAsyncTracker('https://not-supported-piwik.com/matomo.php', 2);
+    // will never issue an HTTP request to configs.php for this Matomo instance
+    var tracker = Matomo.getAsyncTracker('https://not-supported-matomo.com/matomo.php', 2);
     if (tracker.HeatmapSessionRecording) {
         tracker.HeatmapSessionRecording.disable();
     }
@@ -182,9 +182,9 @@ window.matomoAsyncInit = function () {
 
 ## How do I take a screenshot for a heatmap when the heatmap is configured manually via `addConfig()`?  
 
-By default, Piwik will automatically take a screenshot of your web page when the first visitor takes part in your heatmap.
+By default, Matomo will automatically take a screenshot of your web page when the first visitor takes part in your heatmap.
 If you target multiple page URLs for a heatmap, you may want to force generate a screenshot for a specific page URL. 
-When you configure a heatmap, you can therefore define a specific screenshot URL so Piwik will only take a screenshot when 
+When you configure a heatmap, you can therefore define a specific screenshot URL so Matomo will only take a screenshot when 
 this URL is being viewed. 
 
 If you configure a heatmap manually using the [addConfig()](/guides/heatmap-session-recording/reference#addconfig) method,

--- a/docs/5.x/heatmap-session-recording/reference.md
+++ b/docs/5.x/heatmap-session-recording/reference.md
@@ -12,13 +12,13 @@ You may also be interested in the Heatmap & Session Recording [Reporting HTTP AP
 
 In the `matomo.js` tracker we differentiate between two methods:
 
-* Calling a **tracker instance method** affects only a specific Piwik tracker instance. In the docs you can 
+* Calling a **tracker instance method** affects only a specific Matomo tracker instance. In the docs you can 
   identify a tracker method when the method name contains a single dot (`.`), for example 
   `HeatmapSessionRecording.disable`.
 * Calling a **static method** affects all created tracker instances. In the docs you can identify a static method when 
   the method name contains `::`, for example `HeatmapSessionRecording::disableCaptureKeystrokes`.
 
-In most cases only one Piwik tracker will be used so the only difference is how you call that method:
+In most cases only one Matomo tracker will be used so the only difference is how you call that method:
 
 * Tracker methods are called via `_paq.push(['HeatmapSessionRecording.$methodName']);` or on a tracker instance directly eg. 
   `Matomo.getAsyncTracker().HeatmapSessionRecording.$methodName();`
@@ -26,7 +26,7 @@ In most cases only one Piwik tracker will be used so the only difference is how 
   eg. `Matomo.HeatmapSessionRecording.$methodName()`.
 
 If you do not want to use the `_paq.push` methods, you need to define a `window.matomoHeatmapSessionRecordingAsyncInit` method 
-that is called as soon as the media tracker has been initialized:
+that is called as soon as the Heatmap & Session Recording tracker has been initialized:
 
 ```js
 window.matomoHeatmapSessionRecordingAsyncInit = function () {
@@ -55,7 +55,7 @@ window.matomoAsyncInit = function () {
 
 To support single-page websites and web applications out of the box, Heatmap & Session Recording will automatically 
 detect a new page view when you call the `trackPageView` method. This applies if you call `trackPageView` several times without 
-an actual page reload. Piwik will after each call of `trackPageView` stop the recording of any activities and re-evaluate 
+an actual page reload. Matomo will after each call of `trackPageView` stop the recording of any activities and re-evaluate 
 based on the new URL whether if it should record activities for the new page or not. 
  
 If you use `trackPageView` for any other purposes than an actual page view, for example for error or event tracking, 
@@ -104,7 +104,7 @@ whether a new recording should be started, set `fetchConfig = false`.
 
 ### `setMaxCaptureTime(maxTimeInSeconds)`
 
-By default, the activities of a visitor is only recorded for up to 10 minutes in a single page view. If you want to record 
+By default, the activities of a visitor is only recorded for up to 15 minutes in a single page view. If you want to record 
 activities for a longer or shorter period, you can change the limit using this method. 
 
 Example:
@@ -127,11 +127,11 @@ Matomo.HeatmapSessionRecording.setMaxTextInputLength(100000);
 
 ### `disableCaptureKeystrokes()`
 
-When you configure a new session recording in Piwik, you can choose whether keystrokes should be recorded or not. If enabled,
+When you configure a new session recording in Matomo, you can choose whether keystrokes should be recorded or not. If enabled,
 keystrokes that are entered by a user into text form elements will be recorded and replayed later in the recorded session. If 
 you want to make sure to never record any keystrokes entered by your users, call this method.
 
-Password fields and some common credit card fields will be automatically masked before sending the data to your Piwik.
+Password fields and some common credit card fields will be automatically masked before sending the data to your Matomo.
 For privacy reasons you can mask the keystrokes of form fields by setting a `data-matomo-mask` (or `data-piwik-mask`) attribute on any element. 
 Learn more about this in [masking keystrokes](/guides/heatmap-session-recording/setup#masking-keystrokes-in-form-fields).
 
@@ -147,7 +147,7 @@ to certain target groups, to certain times, to certain locations, and more. An e
 
 ### `matchTrackerUrl()`
 
-When you configure a Heatmap or a Session Recording in Piwik, you can define page rules based on URL, URL path and URL parameters
+When you configure a Heatmap or a Session Recording in Matomo, you can define page rules based on URL, URL path and URL parameters
  to limit the recording to certain pages. By default, these rules are matched against the current browser URL.
 If you track custom URLs using the `setCustomUrl()` tracker method and want to apply the configured rules against a possibly set 
 custom URL, call this method.
@@ -161,7 +161,7 @@ By default, the target page rules you configure will be matched against
 ### `disable()`
 
 Allows you to completely disable the tracking of any Heatmap or Session Recording data. This is useful if you for example 
-manage multiple websites in your Piwik and there are some websites where you do not want to track any such activities. It is recommended
+manage multiple websites in your Matomo and there are some websites where you do not want to track any such activities. It is recommended
 to call this method as early in your tracking code as possible or during the `matomoHeatmapSessionRecordingAsyncInit` method.
 
 ### `enable()`
@@ -181,32 +181,32 @@ enabled in production.
 ### `setMatomoTrackers()`
 
 Allows you to set the tracker instances to be used when tracking heatmap and session activities. Can be either
- a single tracker instance, or an array of Piwik tracker instances. This is useful when you are working with multiple Piwik
+ a single tracker instance, or an array of Matomo tracker instances. This is useful when you are working with multiple Matomo
  tracker instances using `Matomo.getTracker` instead of `Matomo.addTracker`. 
  
 ### `getPiwikTrackers()`
 
-Returns an array of Piwik tracker instances that are used by the Heatmap and Session Recording plugin. By default, 
+Returns an array of Matomo tracker instances that are used by the Heatmap and Session Recording plugin. By default, 
 this will return the same as `Matomo.getAsyncTrackers()` and will return all tracker instances that were created eg 
-via `Matomo.addTracker` or `_paq.push(['addTracker']);` unless custom Piwik tracker instances were set via `setMatomoTrackers()`.
+via `Matomo.addTracker` or `_paq.push(['addTracker']);` unless custom Matomo tracker instances were set via `setMatomoTrackers()`.
 
 ## Tracker methods
 
 ### `disable()`
 
-Disables the tracking of any heatmap and session activities. This is useful when you have multiple Piwik tracker
- instances on your website and you want to track activities only into one Piwik. If called early in your tracking code, 
+Disables the tracking of any heatmap and session activities. This is useful when you have multiple Matomo tracker
+ instances on your website and you want to track activities only into one Matomo. If called early in your tracking code, 
  it will not even try to detect whether a recording should be started, saving you one HTTP request on each page view. If you
- use only one Piwik tracker on your website - which is normal in most of the cases - this method is equivalent to 
+ use only one Matomo tracker on your website - which is normal in most of the cases - this method is equivalent to 
  `HeatmapSessionRecording::disable`.
 
 Example:
 
 ```js
-// disables the tracking of any activities on all Piwik trackers
+// disables the tracking of any activities on all Matomo trackers
 _paq.push(['HeatmapSessionRecording::disable']); 
 
-// or if you are using multiple Piwik trackers and only want to disable it for a specific tracker:
+// or if you are using multiple Matomo trackers and only want to disable it for a specific tracker:
 var tracker = Matomo.getAsyncTracker(matomoUrl, matomoSiteId);
 tracker.HeatmapSessionRecording.disable();
 ```
@@ -221,7 +221,7 @@ Detects if the tracking is currently enabled or disabled.
 
 ### `addConfig()`
 
-By default, Heatmap & Session Recording configures itself by issuing an HTTP request to your Piwik installation to
+By default, Heatmap & Session Recording configures itself by issuing an HTTP request to your Matomo installation to
  detect automatically whether any activities should be recorded on the current page. This way you don't need to change
  your website when you configure new heatmaps or session recordings. This HTTP request is executed on each page view 
  and may add some load to your server. If you want to instead configure manually when to record a heatmap or a session, 

--- a/docs/5.x/heatmap-session-recording/setup.md
+++ b/docs/5.x/heatmap-session-recording/setup.md
@@ -5,28 +5,28 @@ title: Setting up
 # Setting up Heatmap & Session Recording
 
 In this guide you will learn how to customize the tracking of [Heatmaps & Session Recordings](https://www.heatmap-analytics.com/).
-By default, you do not need to change your tracking code and Piwik takes care of everything. However, you can adjust the tracking
+By default, you do not need to change your tracking code and Matomo takes care of everything. However, you can adjust the tracking
 in various ways.
 
 ## Embedding the Heatmap & Session Recording JavaScript Tracker
 
-If you have already embedded the [Piwik JavaScript Tracking Code](/guides/tracking-javascript-guide) into your website,
+If you have already embedded the [Matomo JavaScript Tracking Code](/guides/tracking-javascript-guide) into your website,
 the Heatmap & Session Recording will automatically start tracking user activities. The tracking code is directly added 
-in your Piwik JavaScript tracker file `/matomo.js` as long as the file `matomo.js` in your Piwik directory is writable 
+in your Matomo JavaScript tracker file `/matomo.js` as long as the file `matomo.js` in your Matomo directory is writable 
 by the webserver/PHP.
 
-To check whether this works by default for you, login into Piwik as a Super User, go to Administration, and open the "System Check" report. 
+To check whether this works by default for you, login into Matomo as a Super User, go to Administration, and open the "System Check" report. 
 If the System Check displays a warning for "Writable Matomo.js" then [learn below how to solve this](#when-the-matomojs-in-your-piwik-directory-file-is-not-writable).
 
 ## Configuring Heatmaps & Session Recordings
 
-To configure the recording of a session or a heatmap, log in to your Piwik and click on "Heatmaps => Manage" or "Session Recordings => Manage".
+To configure the recording of a session or a heatmap, log in to your Matomo and click on "Heatmaps => Manage" or "Session Recordings => Manage".
 
 There you will be able to configure on which pages you want to record activities and how many sessions should be recorded. 
-Piwik will automatically detect any configured heatmap or session recording and start recording activities when needed. 
+Matomo will automatically detect any configured heatmap or session recording and start recording activities when needed. 
 You don't need to change your tracking code or your website to configure .
 
-To detect if any activities need to be recorded, an HTTP request will be issued on each page view to your Piwik. While this request is 
+To detect if any activities need to be recorded, an HTTP request will be issued on each page view to your Matomo. While this request is 
 fast and does for example not connect to your database, it may still add a bit of load to your server. If you want to avoid such 
 a request on each page view, have a look at the API reference for [`addConfig()`](/guides/heatmap-session-recording/reference#addconfig).
 
@@ -84,15 +84,15 @@ Alternatively, you can mask a set of form fields within your web page by specify
 ```
 
 To force that no keystrokes will be recorded even when enabled in the UI, call `_paq.push(['HeatmapSessionRecording::disableCaptureKeystrokes']);`
-If disabled, no text entered into any form field will be sent to Piwik, not even masked form fields.
+If disabled, no text entered into any form field will be sent to Matomo, not even masked form fields.
 
-## When the `matomo.js` in your Piwik directory file is not writable
+## When the `matomo.js` in your Matomo directory file is not writable
  
-When your Settings > System Check reports that "The Piwik JavaScript tracker file `matomo.js` is not writable 
+When your Settings > System Check reports that "The Matomo JavaScript tracker file `matomo.js` is not writable 
 which means other plugins cannot extend the JavaScript tracker." then you have two options to solve this issue:
 
-1. Make the `matomo.js` file writable, for example by executing `chmod a+w piwik.js` or `chown $phpuser piwik.js` (replace `$phpuser` with actual username) in your Piwik directory. 
-We recommend running the [Piwik console](/guides/piwik-on-the-command-line) command `./console custom-matomo-js:update` after you have made the file writable.
+1. Make the `matomo.js` file writable, for example by executing `chmod a+w matomo.js` or `chown $phpuser matomo.js` (replace `$phpuser` with actual username) in your Matomo directory. 
+We recommend running the [Matomo console](/guides/piwik-on-the-command-line) command `./console custom-matomo-js:update` after you have made the file writable.
 2. or Load the HeatmapSessionRecording tracker file manually in your website by adding in all your pages ideally in the `<head>`: 
    `<script src="https://your-matomo-domain/plugins/HeatmapSessionRecording/tracker.min.js">`
 


### PR DESCRIPTION
## Summary
Fix multiple inaccuracies across form analytics, heatmap, and session recording docs including wrong default values, incorrect file references, and outdated Piwik branding.

## Changes
- docs(heatmap-session-recording/setup): fix piwik.js to matomo.js in chmod/chown and update Piwik branding
- docs(heatmap-session-recording/reference): fix media tracker name, setMaxCaptureTime default, and Piwik branding
- docs(heatmap-session-recording/faq): fix setMaxCaptureTime default, credit card digit range, piwik.js ref, and branding
- docs(heatmap-session-recording): fix Piwik branding to Matomo
- docs(form-analytics/setup): fix piwik.js to matomo.js in chmod/chown and update Piwik branding
- docs(form-analytics/reference): fix setTrackingTimer default from 1.5s to 30s and update Piwik to Matomo
- docs(form-analytics): fix Piwik branding to Matomo and update marketplace link

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules