### PR TITLE
Fix GDPR docs: correct variable names in code examples

### DIFF
--- a/docs/5.x/gdpr.md
+++ b/docs/5.x/gdpr.md
@@ -49,7 +49,7 @@ Your plugin needs to delete any information that is stored along specific visits
 public function deleteDataSubjects(&$result, $visitsToDelete)
 {
     $result['mypluginname'] = 0;
-    foreach($visitsToExport as $visit) {
+    foreach($visitsToDelete as $visit) {
         $result['mypluginname'] += Db::query('DELETE FROM mytable WHERE idsite = ? and idvisit = ?', array($visit['idsite'], $visit['idvisit']))->rowCount();
     }
 }

--- a/docs/5.x/gdpr.md
+++ b/docs/5.x/gdpr.md
@@ -32,7 +32,7 @@ and export features:
 Your plugin needs to export any information that your plugin stores along specific visits like this:
 
 ```php
-public function exportDataSubjects(&export, $visitsToExport)
+public function exportDataSubjects(&$export, $visitsToExport)
 {
     $export['mypluginname'] = array();
     foreach($visitsToExport as $visit) {


### PR DESCRIPTION
## Summary
Fix wrong variable name in deleteDataSubjects example and missing $ sigil in exportDataSubjects example parameter.

## Changes
- docs(gdpr): fix wrong variable name in deleteDataSubjects example
- docs(gdpr): fix missing $ sigil in exportDataSubjects example parameter

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules