### PR TITLE
Fix HTTP request handling docs: correct View constructor syntax

### DIFF
--- a/docs/5.x/http-request-handling.md
+++ b/docs/5.x/http-request-handling.md
@@ -34,7 +34,7 @@ class Controller extends \Piwik\Plugin\Controller
 {
     public function index()
     {
-        $view = new View("@MyPlugin\index.twig");
+        $view = new View("@MyPlugin/index");
         $view->data = \Piwik\Plugins\MyPlugin\API::getInstance()->getData();
         return $view->render();
     }


### PR DESCRIPTION
## Summary
Fix incorrect View constructor example syntax in the HTTP request handling documentation.

## Changes
- docs(http-request-handling): fix View constructor example syntax

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules