### PR TITLE
Fix in-depth Vue docs: correct Field component prop key

### DIFF
--- a/docs/5.x/in-depth-vue.md
+++ b/docs/5.x/in-depth-vue.md
@@ -77,7 +77,7 @@ a custom Vue component:
 
 ```html
 <Field
-    :component="{plugin: 'MyPlugin', component: 'MyFieldComponent'}"
+    :component="{plugin: 'MyPlugin', name: 'MyFieldComponent'}"
 />
 ```
 


### PR DESCRIPTION
## Summary
Fix incorrect Field component prop key from "component" to "name" in the Vue development documentation.

## Changes
- docs(in-depth-vue): fix Field component prop key from component to name

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules