### PR TITLE
Fix log data docs: correct class reference and descriptions

### DIFF
--- a/docs/5.x/log-data.md
+++ b/docs/5.x/log-data.md
@@ -17,7 +17,7 @@ There are five types of log data:
 
 **Log data is aggregated by the [Archiving process](/guides/archiving) into [archive data](/guides/archive-data).**
 
-**Log data is never used directly for Piwik reports**, archive data is used instead. The only exception is the *Live* plugin which uses log data to generate real-time reports.
+**Log data is never used directly for Matomo reports**, archive data is used instead. The only exception is the *Live* plugin which uses log data to generate real-time reports.
 
 ## Persistence
 

--- a/docs/5.x/log-data.md
+++ b/docs/5.x/log-data.md
@@ -23,7 +23,7 @@ There are five types of log data:
 
 Log data is persisted in the database via the `Piwik\Tracker\Visit` handler. Visit properties are represented in PHP as `Piwik\Tracker\Visit\VisitProperties` objects, and stored into the following tables:
 
-- `log_visit` contains one entry per visit (returning visitor)
+- `log_visit` contains one entry per visit
 - `log_action` contains all the type of actions possible on the website (e.g. unique URLs, page titles, download URLs…)
 - `log_link_visit_action` contains one entry per action of a visitor (page view, …)
 - `log_conversion` contains conversions (actions that match goals) that happen during a visit

--- a/docs/5.x/log-data.md
+++ b/docs/5.x/log-data.md
@@ -21,7 +21,7 @@ There are five types of log data:
 
 ## Persistence
 
-Log data is represented in PHP as `Piwik\Tracker\Visit` objects, and is stored into the following tables:
+Log data is persisted in the database via the `Piwik\Tracker\Visit` handler. Visit properties are represented in PHP as `Piwik\Tracker\Visit\VisitProperties` objects, and stored into the following tables:
 
 - `log_visit` contains one entry per visit (returning visitor)
 - `log_action` contains all the type of actions possible on the website (e.g. unique URLs, page titles, download URLs…)


### PR DESCRIPTION
## Summary
Remove misleading "(returning visitor)" from log_visit description, correct PHP class reference from Visit to VisitProperties, and update Piwik branding.

## Changes
- docs(log-data): remove misleading "(returning visitor)" from log_visit description
- docs(log-data): correct PHP class reference from Visit to VisitProperties
- docs(log-data): replace outdated "Piwik reports" with "Matomo reports"

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules