### PR TITLE
Fix misc docs batch 2: correct method names, URLs, and embed code

### DIFF
--- a/docs/5.x/archiving-behavior-specification.md
+++ b/docs/5.x/archiving-behavior-specification.md
@@ -118,7 +118,7 @@ The following classes are involved in the Core Archiving process:
 - **Piwik\Archive**: entry point for archive data queries. This is used by API methods to get numeric and blob data by site ID and/or period.
   If we can't find up to date data for an archive data query, and the current request is allowed to start the core archiving process, we
   initiate archiving. This class will call the CoreAdminHome.archiveReports API method to do so.
-- **Piwik\Loader**: entry point for the core archiving process. The `prepareArchive()` method is invoked directly by CoreAdminHome.archiveReports.
+- **Piwik\ArchiveProcessor\Loader**: entry point for the core archiving process. The `prepareArchive()` method is invoked directly by CoreAdminHome.archiveReports.
   This class is used to look for one individual archive (so for one site and one period). If we can't find a usable one, we launch the core
   archiving process.
   

--- a/docs/5.x/javascript-extended.md
+++ b/docs/5.x/javascript-extended.md
@@ -99,7 +99,7 @@ In your JavaScript, you can use **ColorManager** to access these colors:
     var myColorToUse = ColorManager.getColor('my-color-namespace', 'my-color-name');
 
     // get multiple colors all at once
-    var myColorsToUse = ColorManager.getColor('my-color-namespace', ['my-first-color', 'my-second-color']);
+    var myColorsToUse = ColorManager.getColors('my-color-namespace', ['my-first-color', 'my-second-color']);
 
 })(require);
 ```
@@ -135,7 +135,7 @@ public function myWidget() {
 ```
 
 ```twig
-// MyPlugin/templages/_mywidget.twig
+// MyPlugin/templates/_mywidget.twig
 <p>Hello world!</p>
 ```
 

--- a/docs/5.x/matomo-links.md
+++ b/docs/5.x/matomo-links.md
@@ -114,7 +114,7 @@ With custom campaign parameters:
 
 ```
 var link = _pk_externalRawLink('https://matomo.org/faq/new-to-piwik/faq_17/',
-                'MyCampaign', 'MySource', 'MyMedium');
+                ['MyCampaign', 'MySource', 'MyMedium']);
 ``` 
 
 

--- a/docs/5.x/tracking-api-clients.md
+++ b/docs/5.x/tracking-api-clients.md
@@ -21,13 +21,13 @@ Use the SDKs below for mobile app and product analytics with Matomo.
 
 If you are building iOS apps, Apple tvOs or macOS apps, you can use the Swift PiwikTracker client (or the older Objective-C PiwikTracker) to send tracking data to your Piwik server.
 
-Learn more and download Piwik iOS SDK on GitHub at [github.com/matomo-org/matomo-sdk-ios](https://github.com/matomo-org/piwik-sdk-ios).
+Learn more and download Piwik iOS SDK on GitHub at [github.com/matomo-org/matomo-sdk-ios](https://github.com/matomo-org/matomo-sdk-ios).
 
 ### Android SDK
 
 If you are building Android apps (for Android smartphones, tablets, Fire TVs, etc.), you can use the Android Java client to send tracking data to your Piwik server.
 
-Learn more and download Piwik Android SDK on GitHub at [github.com/matomo-org/matomo-sdk-android](https://github.com/matomo-org/piwik-sdk-android).
+Learn more and download Piwik Android SDK on GitHub at [github.com/matomo-org/matomo-sdk-android](https://github.com/matomo-org/matomo-sdk-android).
 
 ### Appcelerator Titanium Module
 
@@ -41,7 +41,7 @@ Use the clients below for server-side analytics and app tracking with Matomo.
 
 ### PHP client
 
-Learn more about our Piwik Tracking API PHP client on GitHub: [github.com/matomo-org/matomo-php-tracker](https://github.com/matomo-org/piwik-php-tracker).
+Learn more about our Piwik Tracking API PHP client on GitHub: [github.com/matomo-org/matomo-php-tracker](https://github.com/matomo-org/matomo-php-tracker).
 
 ### Java client
 
@@ -49,7 +49,7 @@ A Java client for the Piwik Tracking API is available on GitHub: [github.com/mat
 
 ### C# client
 
-A C# client implementation of the Tracking API is available on GitHub at [github.com/matomo-org/matomo-dotnet-tracker](https://github.com/matomo-org/piwik-dotnet-tracker#piwik-c-tracking-api).
+A C# client implementation of the Tracking API is available on GitHub at [github.com/matomo-org/matomo-dotnet-tracker](https://github.com/matomo-org/matomo-dotnet-tracker).
 
 ### Other clients
 

--- a/docs/5.x/tracking-optout.md
+++ b/docs/5.x/tracking-optout.md
@@ -20,7 +20,7 @@ Using this option the embedded opt-out form code will load Javascript from your 
 
 In order for the [Matomo JavaScript tracking code](/guides/tracking-javascript-guide) to be used by the opt-out it must also be loaded by the same page. A common approach
 is to add both the opt-out form and Matomo JavaScript tracker to the website's Privacy Policy page. If it is not possible to load the Matomo JavaScript tracker on the privacy
-policy page then you can either use the self-contained opt-out form instead or add the `useCookieTimeout=0` URL parameter to avoid waiting for the JavaScript tracker to load.
+policy page then you can either use the self-contained opt-out form instead or add the `useCookiesTimeout=0` URL parameter to avoid waiting for the JavaScript tracker to load.
 
 ### Process
 
@@ -39,7 +39,7 @@ The embedded opt-out form code to add to the website page is simple:
 
 ```
 <div id="matomo-opt-out"></div>
-<script src="https://my-matomo-site.org/index.php?module=CoreAdminHome&action=optOutJS&div=matomo-opt-out></script>\
+<script src="https://my-matomo-site.org/index.php?module=CoreAdminHome&action=optOutJS&divId=matomo-opt-out"></script>
 ```
 
 The opt-out div may be positioned anywhere on the page and can have its own styling. If the div is created dynamically then it must exist when the `DOMContentLoaded`
@@ -47,7 +47,7 @@ event is fired.
 
 Opt-out form configuration options can be passed as URL parameters, the following options are available:
 
-- `div` Specify the id of the div tag in which the opt-out form will be created.
+- `divId` Specify the id of the div tag in which the opt-out form will be created.
 - `language` Override the language used to display the opt-out form text, by default the value `auto` is used which will automatically determine the language to use 
 based on the browser. To force a particular language pass language code such as 'de' or 'en'.
 - `showIntro` Set to `1` if the opt-out form should include text explaining the opt-out choice, set to `0` if the form should just show the checkbox.
@@ -88,7 +88,7 @@ will be made.
 ### Process
 
 - The embedded website `<script>` tag contains around 110 lines of JavaScript.
-- The script executes when the `DomCOntentLoaded` event is fired, indicating the page has finished loading.
+- The script executes when the `DOMContentLoaded` event is fired, indicating the page has finished loading.
 - It checks that the specified opt-out form div exists on the page, if not then an error is shown.
 - The opt-out form is created to set consent cookies directly.
 - If cookies are disabled in the browser or the connection is not `HTTPS` then an error will be shown.

--- a/docs/5.x/working-with-piwiks-ui.md
+++ b/docs/5.x/working-with-piwiks-ui.md
@@ -187,8 +187,8 @@ For example:
 
 Below are some solutions to common problems that may occur during development:
 
-* If working on Vue code and `vue:build --watch` is running but the JavaScript isn't being built properly, try restarting the command. Internally it will
-  clear the webpack cache before watching again, which can solve some problems.
+* If working on Vue code and `vue:build --watch` is running but the JavaScript isn't being built properly, try restarting the command with the
+  `--clear-webpack-cache` flag, which will clear the webpack cache before watching again and can solve some problems.
 * If working on frontend unit tests that use Jest and you are seeing strange errors, clearing Jest's cache can sometimes help. To do this,
   run the `npm test -- --clearCache` command.
 

--- a/docs/migrate-matomo-4-to-5.md
+++ b/docs/migrate-matomo-4-to-5.md
@@ -93,11 +93,11 @@ public function __construct(\Piwik\Log\LoggerInterface $logger)
 
 ### Console Commands
 
-Our console commands were using parts of the Symfony Console library directly. Command classes will no longer be allowed to extend any Symfony components directly, instead we have rewritten our base class for commands `\Piwik\Plugins\ConsoleCommand`. This class will now give you access to console functionalities directly. To update your plugin command you need to apply the following changes:
+Our console commands were using parts of the Symfony Console library directly. Command classes will no longer be allowed to extend any Symfony components directly, instead we have rewritten our base class for commands `\Piwik\Plugin\ConsoleCommand`. This class will now give you access to console functionalities directly. To update your plugin command you need to apply the following changes:
 
 * Methods like `run`, `execute`, `interact` or `initialize` can no longer be overwritten. Instead, use our custom methods prefixed with `do`: `doExecute`, `doInteract` or `doInitialize`
   * `doExecute()` method needs to return integers. We recommend using the class constants `SUCCESS` or `FAILURE` as return values.
-* Wherever you need to work with input or output streams use `$this->getInput()` or `$this->getOutput` instead. Don't use `InputInterface` or `OutputInterface` as method typehints.
+* Wherever you need to work with input or output streams use `$this->getInput()` or `$this->getOutput()` instead. Don't use `InputInterface` or `OutputInterface` as method typehints.
 * When defining input options and arguments `addOption` and `addArgument` can no longer be used
   * For arguments use `addOptionalArgument` or `addRequiredArgument`
   * For options use `addNegatableOption`, `addOptionalValueOption`, `addNoValueOption` or `addRequiredValueOption`


### PR DESCRIPTION
## Summary
Fix various inaccuracies across multiple documentation pages including incorrect method names, outdated GitHub URLs, wrong embed code examples, and stale class references.

## Changes
- docs(matomo-links): fix _pk_externalRawLink custom params call signature
- docs(working-with-piwiks-ui): fix --watch cache clearing claim
- docs(javascript-extended): fix getColors method name and templages typo
- docs(tracking-api-clients): fix old piwik-* GitHub repository URLs
- docs(tracking-optout): fix divId param name, useCookiesTimeout typo, and embed code
- docs(migrate-matomo-4-to-5): fix namespace and missing parentheses
- docs(archiving-behavior-specification): fix incorrect class name Piwik\Loader

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules