### PR TITLE
Fix misc docs batch 4: correct syntax errors, paths, and method names

### DIFF
--- a/docs/5.x/archiving.md
+++ b/docs/5.x/archiving.md
@@ -117,7 +117,7 @@ $serializedData = $dataTable->getSerialized(
     $columnToSortBy = Metrics::INDEX_NB_VISITS
 );
 
-$archiveProcessor->insertBlobRecords('MyPlugin_myFancyReport', $serializedData);
+$archiveProcessor->insertBlobRecord('MyPlugin_myFancyReport', $serializedData);
 ```
 
 Persisted reports and metrics are indexed by the website ID, period and segment. The date and time of archiving is also attached to the data. To learn the specifics of how this is done with MySQL see the [database schema](/guides/database-schema).
@@ -151,7 +151,7 @@ idarchive             | name             | value             | Description
 
 When a report is archived, it is called a **record** not a report. We make a distinction because multiple reports can sometimes be generated from one **record**.
 
-For example, the *UserSettings* plugin uses one record to hold browser details of visitors. This record is used to generate both the `UserSettings.getBrowserVersion` and `UserSettings.getBrowser` reports. The second report simply processes the first to make a new report. The plugin could have archived both reports, but this would have been a **massive** waste of space, considering the new report would be cached for every website/period/segment combination.
+For example, the *DevicesDetection* plugin uses one record to hold browser details of visitors. This record is used to generate both the `DevicesDetection.getBrowserVersions` and `DevicesDetection.getBrowsers` reports. The second report simply processes the first to make a new report. The plugin could have archived both reports, but this would have been a **massive** waste of space, considering the new report would be cached for every website/period/segment combination.
 
 <a name="record-storage-guidelines"></a>
 
@@ -301,7 +301,7 @@ class Archiver extends \Piwik\Plugin\Archiver
                 $columnToSortBy = Metrics::INDEX_NB_VISITS
             );
 
-            $archiveProcessor->insertBlobRecords('MyPlugin_mySpecificReport', $serializedData);
+            $this->getProcessor()->insertBlobRecord('MyPlugin_mySpecificReport', $serializedData);
         }
     }
 

--- a/docs/5.x/piwiks-ini-configuration.md
+++ b/docs/5.x/piwiks-ini-configuration.md
@@ -43,7 +43,7 @@ The [Config](/api-reference/Piwik/Config) singleton allows PHP code to access wh
 For example, the following code will output every config option in the `[General]` section:
 
 ```php
-for (Config::getInstance()->General as $name => $value) {
+foreach (Config::getInstance()->General as $name => $value) {
     echo "Option $name == " . print_r($value, true);
 }
 ```

--- a/docs/5.x/segments.md
+++ b/docs/5.x/segments.md
@@ -38,9 +38,9 @@ Execute the `SegmentEditor.getAll` API method as this should include the expecte
 
 Segments are typically encoded three times:
 
-* The [first decode is on the whole segment](https://github.com/matomo-org/matomo/blob/3.x-dev/core/Segment.php#L104). The corresponding encode was [added in 3.6.0 here](https://github.com/matomo-org/matomo/blob/3.x-dev/plugins/Live/javascripts/SegmentedVisitorLog.js#L123).
-* The [second decode is on individual conditions](https://github.com/matomo-org/matomo/blob/3.x-dev/core/Segment/SegmentExpression.php#L91) (ie, pageUrl==...).
-* The [third decode is on individual values](https://github.com/matomo-org/matomo/blob/3.x-dev/core/Segment/SegmentExpression.php#L112).
+* The [first decode is on the whole segment](https://github.com/matomo-org/matomo/blob/5.x-dev/core/Segment.php#L104). The corresponding encode was [added in 3.6.0 here](https://github.com/matomo-org/matomo/blob/5.x-dev/plugins/Live/javascripts/SegmentedVisitorLog.js#L123).
+* The [second decode is on individual conditions](https://github.com/matomo-org/matomo/blob/5.x-dev/core/Segment/SegmentExpression.php#L91) (ie, pageUrl==...).
+* The [third decode is on individual values](https://github.com/matomo-org/matomo/blob/5.x-dev/core/Segment/SegmentExpression.php#L112).
 
 This means the value needs to be triple encoded for values like plus signs to be used properly in the segment. For more details see [#13481](https://github.com/matomo-org/matomo/pull/13481).
 

--- a/docs/5.x/tracking-consent.md
+++ b/docs/5.x/tracking-consent.md
@@ -62,7 +62,7 @@ _paq.push(['rememberConsentGiven']);
 _paq.push(['rememberCookieConsentGiven']);
 ```
 
-Matomo will then remember on subsequent requests that the user has given their consent by setting a cookie named "consent". As long as this cookie exists, Matomo will know that consent has been given and will automatically process the data. This means that you only need to call `_paq.push(['rememberConsentGiven'])` or `_paq.push(['rememberCookieConsentGiven'])` once.
+Matomo will then remember on subsequent requests that the user has given their consent by setting a cookie named `mtm_consent` (or `mtm_cookie_consent` for cookie consent). As long as this cookie exists, Matomo will know that consent has been given and will automatically process the data. This means that you only need to call `_paq.push(['rememberConsentGiven'])` or `_paq.push(['rememberCookieConsentGiven'])` once.
 
 Notes:
 
@@ -82,7 +82,7 @@ _paq.push(['requireConsent']);
 // OR require user cookie consent before storing any cookies
 _paq.push(['requireCookieConsent']);
 
-_paq.push(['trackPageview']);
+_paq.push(['trackPageView']);
 [...]
 
 // user has given consent to process their data

--- a/docs/5.x/tracking-requests.md
+++ b/docs/5.x/tracking-requests.md
@@ -100,10 +100,10 @@ When we added event tracking or content tracking, we basically simply added a ne
 
 ### Defining a new action
 
-To add such an action, simply create a new file called `Tracker/ActionMyDescriptiveName.php` within a plugin and define a class that extends `Piwik\Tracker\Action`. For example, if a plugin is called `MyPluginName`, then you would create a file in `plugins/MyPluginName/Tracker/ActionMyDescriptiveName.php` and there you would define a class like this:
+To add such an action, simply create a new file called `Actions/ActionMyDescriptiveName.php` within a plugin and define a class that extends `Piwik\Tracker\Action`. For example, if a plugin is called `MyPluginName`, then you would create a file in `plugins/MyPluginName/Actions/ActionMyDescriptiveName.php` and there you would define a class like this:
 
 ```php
-namespace Piwik\Plugins\MyPluginName\Tracker;
+namespace Piwik\Plugins\MyPluginName\Actions;
 
 use Piwik\Tracker\Action;
 


### PR DESCRIPTION
## Summary
Fix various inaccuracies across multiple documentation pages including PHP syntax errors, incorrect file paths, wrong method names, and outdated code links.

## Changes
- docs(piwiks-ini-configuration): fix PHP syntax error, for should be foreach
- docs(segments): update code links from 3.x-dev to 5.x-dev branch
- docs(tracking-consent): fix cookie name and trackPageView capitalization
- docs(tracking-requests): fix action class file path from Tracker/ to Actions/
- docs(archiving): fix incorrect method names and outdated plugin reference

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules