### PR TITLE
Fix permissions docs: add missing role and correct method name

### DIFF
--- a/docs/5.x/permissions.md
+++ b/docs/5.x/permissions.md
@@ -19,7 +19,7 @@ Matomo defines 4 types of permissions:
 
 - [**admin permission**](https://matomo.org/faq/general/faq_69/): applies to a specific site
 
-    With that permission, a user can view and configure a given site (name, URLs, timezone, etc.). They can also grant other users the "view" or "admin" permission.
+    With that permission, a user can view and configure a given site (name, URLs, timezone, etc.). They can also grant other users the "view", "write", or "admin" permission.
 
 - [**super user permission**](https://matomo.org/faq/general/faq_35/): applies to **whole Matomo** (all sites)
 

--- a/docs/5.x/permissions.md
+++ b/docs/5.x/permissions.md
@@ -3,11 +3,11 @@ category: Develop
 ---
 # User permissions
 
-Permissions define what a user can see or do in Piwik.
+Permissions define what a user can see or do in Matomo.
 
 ## Users and permissions
 
-Piwik defines 4 types of permissions:
+Matomo defines 4 types of permissions:
 
 - [**view permission**](https://matomo.org/faq/general/faq_70/): applies to a specific site
 
@@ -21,7 +21,7 @@ Piwik defines 4 types of permissions:
 
     With that permission, a user can view and configure a given site (name, URLs, timezone, etc.). They can also grant other users the "view" or "admin" permission.
 
-- [**super user permission**](https://matomo.org/faq/general/faq_35/): applies to **whole Piwik** (all sites)
+- [**super user permission**](https://matomo.org/faq/general/faq_35/): applies to **whole Matomo** (all sites)
 
     With that permission, a user can view and configure all sites. They can also perform all administrative tasks such as add new sites, add users, change user permissions, activate and deactivate plugins or install new ones from the Marketplace.
 
@@ -101,7 +101,7 @@ Piwik::checkUserHasAdminAccess($idSites = array(1,2,3));
 
 ### Super user permission
 
-A user having the super user permission is allowed to access all data stored in Piwik and change any settings. To check if a user has this role use any of the methods that end with `UserSuperUserAccess`.
+A user having the super user permission is allowed to access all data stored in Matomo and change any settings. To check if a user has this role use any of the methods that end with `UserSuperUserAccess`.
 
 ```php
 Piwik::checkUserHasSuperUserAccess();

--- a/docs/5.x/permissions.md
+++ b/docs/5.x/permissions.md
@@ -44,7 +44,7 @@ To check a user's permissions, you need to `use` the [`Piwik\Piwik`](https://dev
     public function deleteAllMessages()
     {
         // delete messages only if user has super user access, otherwise show an error message
-        Piwik::checkUserSuperUserAccess();
+        Piwik::checkUserHasSuperUserAccess();
 
         $this->getModel()->deleteAllMessages();
     }


### PR DESCRIPTION
## Summary
Add missing "write" role to admin permission description, fix incorrect method name checkUserSuperUserAccess to checkUserHasSuperUserAccess, and update Piwik branding.

## Changes
- Add missing "write" role to admin permission description
- Fix incorrect method name checkUserSuperUserAccess -> checkUserHasSuperUserAccess
- Replace outdated "Piwik" branding with "Matomo" in prose text

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules