### PR TITLE
Fix providing updates docs: correct change order and display duration

### DIFF
--- a/docs/5.x/providing-updates.md
+++ b/docs/5.x/providing-updates.md
@@ -34,5 +34,5 @@ To add "What's new?" change notifications for your plugin, create a `changes.jso
 | link        | URL of the link, optional. |
 
 Whenever a plugin is installed or updated any new entries in the `changes.json` file will be loaded into the `changes` database
-table and shown when the "What's New?" menu icon is clicked. Change notifications are loaded in the same order as they appear in
-the `changes.json` file and will be shown for ninety days from the date that they were loaded. 
+table and shown when the "What's New?" menu icon is clicked. Change notifications are loaded in reverse order from how they appear in
+the `changes.json` file, so the last entry in the file will be displayed first. Changes will be shown for six months from the date that they were loaded. 


### PR DESCRIPTION
## Summary
Fix incorrect change order description and display duration in the providing updates documentation.

## Changes
- docs(providing-updates): fix incorrect change order and display duration

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules