### PR TITLE
Fix reporting API tutorial: correct URLs, examples, and spelling

### DIFF
--- a/docs/5.x/reporting-api-tutorial.md
+++ b/docs/5.x/reporting-api-tutorial.md
@@ -64,7 +64,7 @@ Here is the output of this request:
 [https://demo.matomo.cloud/?module=API&method=Referrers.getReferrerType&idSite=1&period=day&date=last10&format=xml](https://demo.matomo.cloud/?module=API&method=Referrers.getReferrerType&idSite=1&period=day&date=last10&format=xml)
 
 
-*   RSS feed containing the top 30 pages for the last 3 weeks
+*   RSS feed containing the top 30 search engine keywords for the last 3 weeks
 [https://demo.matomo.cloud/?module=API&method=Referrers.getKeywords&idSite=1&period=week&date=last3&format=rss&filter_limit=30](https://demo.matomo.cloud/?module=API&method=Referrers.getKeywords&idSite=1&period=week&date=last3&format=rss&filter_limit=30)
 
 

--- a/docs/5.x/reporting-api-tutorial.md
+++ b/docs/5.x/reporting-api-tutorial.md
@@ -72,7 +72,7 @@ Here is the output of this request:
 [https://demo.matomo.cloud/?module=API&method=Actions.getPageTitles&idSite=1&period=day&date=last3&format=xml&filter_column=label&filter_pattern=store](https://demo.matomo.cloud/?module=API&method=Actions.getPageTitles&idSite=1&period=day&date=last3&format=xml&filter_column=label&filter_pattern=store)
 
 *   XML containing search engine keywords from the last 3 weeks, one entry per week
-[https://demo.matomo.cloud/?module=API&method=Referrers.getKeywords&idSite=1&period=week&date=last3&translateColumnNames=1&format=xml](https://demo.matomo.cloud/?module=API&method=Referrers.getKeywords&idSite=1&period=week&date=last3&translateColumnNames=1format=xml)
+[https://demo.matomo.cloud/?module=API&method=Referrers.getKeywords&idSite=1&period=week&date=last3&translateColumnNames=1&format=xml](https://demo.matomo.cloud/?module=API&method=Referrers.getKeywords&idSite=1&period=week&date=last3&translateColumnNames=1&format=xml)
 
 
 You can get the data in one of these formats: XML, JSON, HTML, CSV, TSV, etc. See the [API Reference](/api-reference/reporting-api) for the documentation.

--- a/docs/5.x/reporting-api-tutorial.md
+++ b/docs/5.x/reporting-api-tutorial.md
@@ -60,7 +60,7 @@ Here is the output of this request:
 *   XML of the visits of the last 10 days, one entry per day
 [https://demo.matomo.cloud/?module=API&method=VisitsSummary.getVisits&idSite=1&period=day&date=last10&format=xml](https://demo.matomo.cloud/?module=API&method=VisitsSummary.getVisits&idSite=1&period=day&date=last10&format=xml)
 
-*   XML of the visits by Aquisition Channel 
+*   XML of the visits by Acquisition Channel 
 [https://demo.matomo.cloud/?module=API&method=Referrers.getReferrerType&idSite=1&period=day&date=last10&format=xml](https://demo.matomo.cloud/?module=API&method=Referrers.getReferrerType&idSite=1&period=day&date=last10&format=xml)
 
 

--- a/docs/5.x/reporting-api-tutorial.md
+++ b/docs/5.x/reporting-api-tutorial.md
@@ -31,7 +31,7 @@ To build the URL of the API call, you need:
 
     **period=day**
 
-    Alternatively, if you wanted to request all pages from a given date, you could use a date range parameter. For example, to request all pages since January 1st 2021:`period=range&date=2011-01-21,yesterday`
+    Alternatively, if you wanted to request all pages from a given date, you could use a date range parameter. For example, to request all pages since January 1st 2021:`period=range&date=2021-01-01,yesterday`
 
 - the format parameter. Defines the output format of the data: XML, JSON, CSV, PHP (serialized PHP), HTML (simple html)
 


### PR DESCRIPTION
## Summary
Fix broken URL missing ampersand separator, correct date range example to match its description, fix misleading RSS feed example, and fix spelling of Acquisition.

## Changes
- docs(reporting-api-tutorial): fix spelling of Acquisition
- docs(reporting-api-tutorial): fix date range example to match description
- docs(reporting-api-tutorial): fix misleading RSS feed example description
- docs(reporting-api-tutorial): fix broken URL missing & separator

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules