### PR TITLE
Fix security docs: update deprecated methods and fix examples

### DIFF
--- a/docs/5.x/security-in-piwik.md
+++ b/docs/5.x/security-in-piwik.md
@@ -235,8 +235,6 @@ Here are some other coding guidelines that will help make your code more secure:
 
 - **Make sure that accessing your files directly doesn't execute any code that could have an impact on your Piwik install.**
 
-- **Make sure your code doesn't rely on `register_globals` set to `On`. Note: PHP5 sets `register_globals` to `Off` by default.**
-
 - **For timing attack safe equal comparisons use `Common::hashEquals()` method**
 
 - **If your plugin has admin functionality (functionality only an administrator or the super user can use) then your plugin's Controller must extend [Piwik\Plugin\ControllerAdmin](/api-reference/Piwik/Plugin/ControllerAdmin).**

--- a/docs/5.x/security-in-piwik.md
+++ b/docs/5.x/security-in-piwik.md
@@ -18,14 +18,18 @@ Attackers can achieve that either by:
 
 ### Get request parameters safely
 
-In your PHP code, if you need access to a variable in `$_GET` or `$_POST`, use the `Request` class:
+In your PHP code, if you need access to a variable in `$_GET` or `$_POST`, use the `Request` class. Prefer the type-safe methods that validate and cast the value for you:
 
 ```php
 $request = new \Piwik\Request();
-$idSite = $request->getParameter('idSite');
+$idSite  = $request->getIntegerParameter('idSite');
+$segment = $request->getStringParameter('segment', '');
+$flat    = $request->getBoolParameter('flat', false);
 ```
 
-> Note: `Common::getRequestVar()` is deprecated. Use `\Piwik\Request::getParameter()` instead. Unlike `getRequestVar()`, the `Request` class returns raw (unsanitized) values, so make sure to apply proper escaping when outputting values in HTML.
+Available type-safe methods: `getIntegerParameter()`, `getStringParameter()`, `getFloatParameter()`, `getBoolParameter()`, `getArrayParameter()`, `getJsonParameter()`. Use the untyped `getParameter()` only when the expected type can genuinely vary.
+
+> Note: `Common::getRequestVar()` is deprecated. Use the `\Piwik\Request` class instead. Unlike `getRequestVar()`, the `Request` class returns raw (unsanitized) values, so make sure to apply proper escaping when outputting values in HTML.
 
 The older `getRequestVar()` method sanitizes request variables automatically. If an attacker passes a string containing `<script>...</script>`, it will be sanitized to `&lt;script&gt;...&lt;/script&gt;`. This will help to avoid accidentally embedding unescaped text in HTML output.
 

--- a/docs/5.x/security-in-piwik.md
+++ b/docs/5.x/security-in-piwik.md
@@ -16,11 +16,18 @@ Attackers can achieve that either by:
 - storing malicious scripts in data (like website names for Piwik)
 - passing malicious scripts as HTTP request parameter/data
 
-### Get request parameters via [Common::getRequestVar()](/api-reference/Piwik/Common#getrequestvar)
+### Get request parameters safely
 
-In your PHP code, if you need access to a variable in `$_GET` or `$_POST`, **always** use [Common::getRequestVar()](/api-reference/Piwik/Common#getrequestvar).
+In your PHP code, if you need access to a variable in `$_GET` or `$_POST`, use the `Request` class:
 
-`getRequestVar()` will sanitize the request variable. If an attacker passes a string containing `<script>...</script>`, it will be sanitized to `&lt;script&gt;...&lt;/script&gt;`. This will help to avoid accidentally embedding unescaped text in HTML output.
+```php
+$request = new \Piwik\Request();
+$idSite = $request->getParameter('idSite');
+```
+
+> Note: `Common::getRequestVar()` is deprecated. Use `\Piwik\Request::getParameter()` instead. Unlike `getRequestVar()`, the `Request` class returns raw (unsanitized) values, so make sure to apply proper escaping when outputting values in HTML.
+
+The older `getRequestVar()` method sanitizes request variables automatically. If an attacker passes a string containing `<script>...</script>`, it will be sanitized to `&lt;script&gt;...&lt;/script&gt;`. This will help to avoid accidentally embedding unescaped text in HTML output.
 
 For text you know may contain special characters or if you need to output text in a format that doesn't need XML/HTML sanitization (like JSON), call [Common::unsanitizeInputValues()](/api-reference/Piwik/Common#unsanitizeinputvalues) to undo the sanitization.
 

--- a/docs/5.x/security-in-piwik.md
+++ b/docs/5.x/security-in-piwik.md
@@ -22,9 +22,9 @@ In your PHP code, if you need access to a variable in `$_GET` or `$_POST`, **alw
 
 `getRequestVar()` will sanitize the request variable. If an attacker passes a string containing `<script>...</script>`, it will be sanitized to `&lt;script&gt;...&lt;/script&gt;`. This will help to avoid accidentally embedding unescaped text in HTML output.
 
-For text you know may contain special characters or if you need to output text in a format that doesn't need XML/HTML sanitization (like JSON), call [Piwik::unsanitizeInputValues()](/api-reference/Piwik/Common#unsanitizeinputvalues) to undo the sanitization.
+For text you know may contain special characters or if you need to output text in a format that doesn't need XML/HTML sanitization (like JSON), call [Common::unsanitizeInputValues()](/api-reference/Piwik/Common#unsanitizeinputvalues) to undo the sanitization.
 
-*Note: You can sanitize text that isn't in a request parameter by using [Piwik::sanitizeInputValues()](/api-reference/Piwik/Common#sanitizeinputvalues).*
+*Note: You can sanitize text that isn't in a request parameter by using [Common::sanitizeInputValues()](/api-reference/Piwik/Common#sanitizeinputvalues).*
 
 ### Use the correct Twig escaping strategy
 

--- a/docs/5.x/security-in-piwik.md
+++ b/docs/5.x/security-in-piwik.md
@@ -68,7 +68,7 @@ $('#someLabel').text( safeString );
 [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) is set by default in Matomo (since Matomo 4.6.0) and plugins can modify the CSP as needed using `$this->securityPolicy` methods in the controller, for example:
 
 ```php
-$this->securityPolicy->addPolicy('image-src', 'self');
+$this->securityPolicy->addPolicy('img-src', 'self');
 ```
 
 Or using dependency injection by creating a `plugins/MyPlugin/config/config.php` like this to apply the change to every UI request instead of only a specific request:


### PR DESCRIPTION
## Summary
Note Common::getRequestVar() deprecation with recommendation to use Request class, remove obsolete register_globals warning, fix incorrect CSP directive name, and correct class names in display text.

## Changes
- docs(security-in-piwik): note Common::getRequestVar() deprecation and recommend Request class
- docs(security-in-piwik): remove obsolete register_globals warning
- docs(security-in-piwik): fix incorrect CSP directive name in example
- docs(security-in-piwik): fix wrong class name in display text for sanitize methods

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules