### PR TITLE
Fix Tag Manager docs: update embed code and fix paths

### DIFF
--- a/docs/5.x/tagmanager/custom-tag.md
+++ b/docs/5.x/tagmanager/custom-tag.md
@@ -28,7 +28,7 @@ This command will guide you through the creation of a tag and ask for several th
 
 ### Defining the name, description, and help of your tag
 
-When you generate a tag, the generator will automatically create some [translation keys](/guides/translations) in your `plugin/$yourplugin/lang/en.json` file.
+When you generate a tag, the generator will automatically create some [translation keys](/guides/translations) in your `plugins/$yourplugin/lang/en.json` file.
 You may want to adjust the translations for the created keys:
 
 ```json

--- a/docs/5.x/tagmanager/custom-trigger.md
+++ b/docs/5.x/tagmanager/custom-trigger.md
@@ -29,7 +29,7 @@ This command will guide you through the creation of a trigger and ask for severa
 
 ### Defining the name, description, and help of your trigger
 
-When you generate a trigger, the generator will automatically create some [translation keys](/guides/translations) in your `plugin/$yourplugin/lang/en.json` file.
+When you generate a trigger, the generator will automatically create some [translation keys](/guides/translations) in your `plugins/$yourplugin/lang/en.json` file.
 You may want to adjust the translations for the created keys:
 
 ```json
@@ -91,7 +91,7 @@ public function getParameters()
     return array(
         $this->makeSetting('listenEvent', 'all', FieldConfig::TYPE_STRING, function (FieldConfig $field) {
             $field->title = 'Trigger when network status changes to';
-            $field->uiControl = FieldConfig::UI_CONTROL_SELECT;
+            $field->uiControl = FieldConfig::UI_CONTROL_SINGLE_SELECT;
             $field->availableValues = array(
                 'all' => 'Online or Offline',
                 'online' => 'Online',

--- a/docs/5.x/tagmanager/custom-variable.md
+++ b/docs/5.x/tagmanager/custom-variable.md
@@ -36,7 +36,7 @@ $ ./console generate:tagmanager-preconfigured-variable
 
 ### Defining the name, description, and help of your variable
 
-When you generate a variable, the generator will automatically create some [translation keys](/guides/translations) in your `plugin/$yourplugin/lang/en.json` file.
+When you generate a variable, the generator will automatically create some [translation keys](/guides/translations) in your `plugins/$yourplugin/lang/en.json` file.
 You may want to adjust the translations for the created keys:
 
 ```json

--- a/docs/5.x/tagmanager/embedding.md
+++ b/docs/5.x/tagmanager/embedding.md
@@ -22,12 +22,12 @@ The code looks as follows:
 
 ```html
 <!-- Matomo Tag Manager -->
-<script type="text/javascript">
-  window._mtm = window._mtm || [];
-  window._mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+<script>
+  var _mtm = window._mtm = window._mtm || [];
+  _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
   (function() {
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.src='https://{$MATOMO_URL}/js/container_{$CONTAINER_ID}.js'; s.parentNode.insertBefore(g,s);
+    g.async=true; g.src='https://{$MATOMO_URL}/js/container_{$CONTAINER_ID}.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
 <!-- End Matomo Tag Manager -->

--- a/docs/5.x/tagmanager/integration-plugin.md
+++ b/docs/5.x/tagmanager/integration-plugin.md
@@ -14,12 +14,12 @@ The easiest way to embed a container without needing any authentication is to as
 
 ```html
 <!-- Matomo Tag Manager -->
-<script type="text/javascript">
-  window._mtm = window._mtm || [];
-  window._mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+<script>
+  var _mtm = window._mtm = window._mtm || [];
+  _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
   (function() {
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-    g.type='text/javascript'; g.async=true; g.src='https://{$MATOMO_URL}/js/container_{$CONTAINER_ID}.js'; s.parentNode.insertBefore(g,s);
+    g.async=true; g.src='https://{$MATOMO_URL}/js/container_{$CONTAINER_ID}.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
 <!-- End Matomo Tag Manager -->
@@ -30,11 +30,11 @@ Where you replace the `{$MATOMO_URL}` with the configured URL and `{$CONTAINER_I
 Alternatively, you could also simply add this to the `<head>` (preferred) or `<body>` directly:
 
 ```html
-<script type="text/javascript">
-window._mtm = window._mtm || [];
-window._mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+<script>
+var _mtm = window._mtm = window._mtm || [];
+_mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
 </script>
-<script type="text/javascript" src="{$MATOMO_URL}/js/container_{$CONTAINER_ID}.js" async="true" defer="true"></script>
+<script src="{$MATOMO_URL}/js/container_{$CONTAINER_ID}.js" async="true" defer="true"></script>
 ```
 
 If possible, we recommend offering this simple way as users won't need to configure an API token which increases the security. Also, it is an easy way for an integration developer to implement it.

--- a/docs/5.x/tagmanager/parameters.md
+++ b/docs/5.x/tagmanager/parameters.md
@@ -39,14 +39,14 @@ simply set the template file to one of these values:
 ```php
 // a text field that allows the user to choose a variable
 $field->uiControl = FieldConfig::UI_CONTROL_TEXT;
-$field->customUiControlTemplateFile = self::FIELD_TEMPLATE_VARIABLE;
+$field->customFieldComponent = self::FIELD_VARIABLE_COMPONENT;
 
 // a textarea that allows the user to choose a variable
 $field->uiControl = FieldConfig::UI_CONTROL_TEXTAREA;
-$field->customUiControlTemplateFile = self::FIELD_TEMPLATE_TEXTAREA_VARIABLE;
+$field->customFieldComponent = self::FIELD_TEXTAREA_VARIABLE_COMPONENT;
 
 // requires the user to select a "MatomoConfigurationVariable"
-$field->customUiControlTemplateFile = self::FIELD_TEMPLATE_VARIABLE_TYPE;
+$field->customFieldComponent = self::FIELD_VARIABLE_TYPE_COMPONENT;
 $field->uiControlAttributes = array('variableType' => 'MatomoConfiguration');
 ```
 
@@ -78,6 +78,7 @@ public function getParameters()
             }
         }),
     );
+}
 ```
 
 ### Validating a value

--- a/docs/5.x/tagmanager/settingup.md
+++ b/docs/5.x/tagmanager/settingup.md
@@ -15,6 +15,6 @@ Alternatively, you may also [release](/guides/distributing-your-plugin) a tag or
 
 ## Guides & API references
 
-* Are you new to the Matomo Tag Manager? Check out our [user guide]().
+* Are you new to the Matomo Tag Manager? Check out our [user guide](https://matomo.org/guide/tag-manager/).
 * Want to integrate Matomo Tag Manager into your website? Check out our [integration guide](/guides/tagmanager/introduction).
 * Looking for the Tag Manager API Reference? Check out our [JavaScript Tag Manager API Reference](/api-reference/tagmanager/javascript-api-reference).


### PR DESCRIPTION
## Summary
Update embed code snippets to match current output, fix plugin directory paths, correct variable selection API references, and fix broken links.

## Changes
- docs(integration-plugin): update embed code snippets to match current output
- docs(embedding): update embed code snippet to match current output
- docs(parameters): fix obsolete variable selection API and missing brace
- docs(custom-variable): fix plugin/ to plugins/ in translation path
- docs(custom-trigger): fix UI_CONTROL_SELECT and plugin/ path
- docs(custom-tag): fix plugin/ to plugins/ in translation path
- docs(settingup): fix broken user guide link

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules