### PR TITLE
Fix PHP tests docs: correct PHPUnit version and base class

### DIFF
--- a/docs/5.x/tests-php.md
+++ b/docs/5.x/tests-php.md
@@ -226,7 +226,7 @@ Plugins sometimes define their own version of this test.
 
 * When possible prefer using `assertSame` over `assertEquals` so it does an exact comparison (including type)
 * Know the other methods like instead of `$this->assertSame(1, count($array))` use `$this->assertCount(1, $array)`
-* See the [full list of available assertions](https://phpunit.readthedocs.io/en/9.5/assertions.html).
+* See the [full list of available assertions](https://phpunit.readthedocs.io/en/8.5/assertions.html).
 
 ### Compare the entire variable 
 
@@ -330,7 +330,7 @@ This ensures that the test execution won't stop in the middle if one of them fai
 
 ### Related links
 
-* [Writing tests for PHP Unit](https://phpunit.readthedocs.io/en/9.5/writing-tests-for-phpunit.html)
+* [Writing tests for PHP Unit](https://phpunit.readthedocs.io/en/8.5/writing-tests-for-phpunit.html)
 * [Five Tips to Improve Your Unit Testing](https://kore-nordmann.de/blog/105_five_tips_improve_unit_testing.html)
 * [Testing the untestable](https://kore-nordmann.de/blog/102_testing_the_untestable.html)
 

--- a/docs/5.x/tests-php.md
+++ b/docs/5.x/tests-php.md
@@ -98,7 +98,7 @@ The command will ask you for the name of the plugin and the name of the test (wh
  * @group WidgetsTest
  * @group Plugins
  */
-class WidgetsTest extends UnitTestCase
+class WidgetsTest extends \PHPUnit\Framework\TestCase
 {
     public function testSimpleAddition()
     {


### PR DESCRIPTION
## Summary
Update PHPUnit documentation links from 9.5 to 8.5 to match the installed version, and fix unit test base class from UnitTestCase to the correct PHPUnit\Framework\TestCase.

## Changes
- docs(tests-php): update PHPUnit doc links from 9.5 to 8.5 to match installed version
- docs(tests-php): fix unit test base class from UnitTestCase to \PHPUnit\Framework\TestCase

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules