### PR TITLE
Fix system tests docs: correct paths, namespaces, and API references

### DIFF
--- a/docs/5.x/tests-system.md
+++ b/docs/5.x/tests-system.md
@@ -74,7 +74,7 @@ public function getApiForTesting()
 
     return array(
         // test a single API method
-        array('UserSettings.getResolution', array('idSite' => $idSite, 'date' => $dateTime)),
+        array('Resolution.getResolution', array('idSite' => $idSite, 'date' => $dateTime)),
 
         // test all methods in a plugin
         array('API', array('idSite' => $idSite, 'date' => $dateTime)),
@@ -88,7 +88,7 @@ public function getApiForTesting()
                                           'otherRequestParameters' => array('urls' => $bulkUrls))),
 
         // test multiple dates w/ multiple periods and multiple sites
-        array('UserSettings.getResolution', array('idSite' => 'all',
+        array('Resolution.getResolution', array('idSite' => 'all',
                                                   'date' => $dateTime,
                                                   'periods' => array('day', 'week', 'month'),
                                                   'setDateLastN' => true)),

--- a/docs/5.x/tests-system.md
+++ b/docs/5.x/tests-system.md
@@ -42,7 +42,7 @@ If we don't update the OmniFixture then we end up with many failed screenshots t
 As part of our system tests we generate the scheduled reports (in HTML, PDF & SMS).
 Some of these scheduled reports contain PNG graphs. Depending on the system under test, generated images can differ.
 Therefore, PNG graphs are only tested and compared against "expected" graphs, if the system under test has the same characteristics as the integration server.
-The characteristics of the integration server are described in `SystemTestCase::canImagesBeIncludedInScheduledReports()`
+The characteristics of the integration server are described in `Fixture::canImagesBeIncludedInScheduledReports()`
 
 ## Writing system tests
 

--- a/docs/5.x/tests-system.md
+++ b/docs/5.x/tests-system.md
@@ -210,7 +210,7 @@ class CheckDirectDependencyUseCommandTest extends SystemTestCase
 {
     public function testCommand()
     {
-        if (version_compare(Version::VERSION, '5.1.0', '<=') || !file_exists(PIWIK_INCLUDE_PATH . '/plugins/TestRunner/Commands/CheckDirectDependencyUse.php')) {
+        if (version_compare(Version::VERSION, '5.1.0', '<') || !file_exists(PIWIK_INCLUDE_PATH . '/plugins/TestRunner/Commands/CheckDirectDependencyUse.php')) {
             $this->markTestSkipped('tests:check-direct-dependency-use is not available in this version');
           }
         

--- a/docs/5.x/tests-system.md
+++ b/docs/5.x/tests-system.md
@@ -138,7 +138,7 @@ You can create your own fixture as well, just extend `Piwik\Tests\Framework\Fixt
 
 ## Expected and processed output
 
-System tests will generate an expected output file for every API method and period combination. The generated output (also called *processed* output) is stored in the `processed/` subdirectory of your plugin's `Test/` directory. The expected output should be stored in a directory named `expected/`.
+System tests will generate an expected output file for every API method and period combination. The generated output (also called *processed* output) is stored in the `processed/` subdirectory of your plugin's `tests/System/` directory. The expected output should be stored in a directory named `expected/`.
 
 When you first create a system test, there will be no expected files. You will have to copy processed files to the expected folder after ensuring they are correct.
 

--- a/docs/5.x/tests-system.md
+++ b/docs/5.x/tests-system.md
@@ -134,7 +134,7 @@ MySystemTest::$fixture = new \Piwik\Tests\Fixtures\ThreeGoalsOnePageview();
 
 To see the fixtures Piwik defines, see the files in the `tests/PHPUnit/Fixtures` directory.
 
-You can create your own fixture as well, just extend `Piwik\Tests\Framework\Fixture` and place the file in the `Test/Fixtures/` directory of your plugin.
+You can create your own fixture as well, just extend `Piwik\Tests\Framework\Fixture` and place the file in the `tests/Fixtures/` directory of your plugin.
 
 ## Expected and processed output
 

--- a/docs/5.x/tests-system.md
+++ b/docs/5.x/tests-system.md
@@ -129,7 +129,7 @@ class MySystemTest extends SystemTestCase
     // ...
 }
 
-MySystemTest::$fixture = new \Test_Piwik_Fixture_ThreeGoalsOnePageview();
+MySystemTest::$fixture = new \Piwik\Tests\Fixtures\ThreeGoalsOnePageview();
 ```
 
 To see the fixtures Piwik defines, see the files in the `tests/PHPUnit/Fixtures` directory.


### PR DESCRIPTION
## Summary
Fix multiple inaccuracies in system test documentation including wrong output directory, incorrect version_compare operator, wrong fixture paths, outdated plugin references, and incorrect class attribution.

## Changes
- docs(tests-system): fix plugin test output directory from Test/ to tests/System/
- docs(tests-system): fix version_compare operator from <= to <
- docs(tests-system): fix plugin fixture directory path to tests/Fixtures/
- docs(tests-system): update fixture class name to PSR-4 namespace
- docs(tests-system): replace stale UserSettings.getResolution with Resolution.getResolution
- docs(tests-system): fix class attribution for canImagesBeIncludedInScheduledReports()

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules