### PR TITLE
Fix views docs: remove .twig extension and update branding

### DIFF
--- a/docs/5.x/views.md
+++ b/docs/5.x/views.md
@@ -33,9 +33,9 @@ The preferred way to generate anything text-based (like HTML) using data is to d
 
 ### Template storage and referencing
 
-Templates are stored in the `templates/` subdirectory of a plugin's root directory. When you create a [View](/api-reference/Piwik/View) instance you must tell it what template it should use using a string with the following format: `"@PluginName/TemplateFileName"`. Piwik will look for a file named `TemplateFileName.twig` in the **PluginName** plugin's `templates/` subdirectory.
+Templates are stored in the `templates/` subdirectory of a plugin's root directory. When you create a [View](/api-reference/Piwik/View) instance you must tell it what template it should use using a string with the following format: `"@PluginName/TemplateFileName"`. Matomo will look for a file named `TemplateFileName.twig` in the **PluginName** plugin's `templates/` subdirectory.
 
-Template files in Piwik have a very specific naming convention. If the file contains the output for a specific controller method, the file should be named after the method. For example, `myControllerMethod.twig`. In all other cases, the file should be named after what it contains and be prefixed with an underscore. For example, `_myEmbeddedWidget.twig`.
+Template files in Matomo have a very specific naming convention. If the file contains the output for a specific controller method, the file should be named after the method. For example, `myControllerMethod.twig`. In all other cases, the file should be named after what it contains and be prefixed with an underscore. For example, `_myEmbeddedWidget.twig`.
 
 ### Twig functions and filters
 
@@ -43,7 +43,7 @@ The [View](/api-reference/Piwik/View) class adds several filters and functions b
 
 ## UI Components and Styles
 
-Piwik has a UI demo page available. This page is intended to show all the UI components and styles available to use in Piwik. To view the demo page:
+Matomo has a UI demo page available. This page is intended to show all the UI components and styles available to use in Matomo. To view the demo page:
 
 1. Go to the Administration page (gear icon)
 2. In the navigation menu, under _Development_, select  _UI Demo_

--- a/docs/5.x/views.md
+++ b/docs/5.x/views.md
@@ -8,7 +8,7 @@ Views are classes that implement `ViewInterface`. The main view class [Piwik\Vie
 Using a view is straightforward. First, it is configured. The meaning of this is different based on the View type. For [Piwik\View](/api-reference/Piwik/View) instances, it simply means setting properties. For example:
 
 ```php
-$view = new View("@MyPlugin/myTemplate.twig");
+$view = new View("@MyPlugin/myTemplate");
 
 // set properties
 $view->property1 = 'property1';


### PR DESCRIPTION
## Summary
Remove incorrect .twig extension from View constructor example and replace Piwik with Matomo branding in the views guide.

## Changes
- Replace Piwik with Matomo in views guide
- Remove .twig extension from View constructor example in views guide

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules