### PR TITLE
Fix visualizing report data docs: update deprecated APIs

### DIFF
--- a/docs/5.x/visualizing-report-data.md
+++ b/docs/5.x/visualizing-report-data.md
@@ -111,19 +111,24 @@ The `index.twig` template will look like this:
 
 ### Displaying reports in the Dashboard
 
-A report can also be made available to the dashboard by using the [`WidgetsList.addWidgets`](/api-reference/events#widgetslistaddwidgets) event:
+A report can be made available to the dashboard by defining a widget. The recommended approach is to configure widgets in your report's `configureWidgets()` method using `WidgetConfig` objects:
 
 ```php
-// event handler for the WidgetsList.addWidgets event in the MyPlugin/MyPlugin.php file
-public function addWidgets()
+class GetMyReport extends \Piwik\Plugin\Report
 {
-    WidgetsList::add('My Category Name', 'My Report Title', 'MyPlugin', 'myReport');
+    protected function configureWidgets(WidgetsList $widgetsList, ReportWidgetFactory $factory)
+    {
+        $widget = $factory->createWidget();
+        $widgetsList->addWidgetConfig($widget);
+    }
 }
 ```
 
+Alternatively, you can create a standalone widget class in your plugin's `Widgets/` directory.
+
 Piwik users will then be able to see and select **myReport** in the widget selector.
 
-*Note: Any controller method can be embedded in the dashboard, not just reports. So if you have a popup that you'd like to make available as a dashboard widget, you can use [WidgetsList.addWidgets](/api-reference/events#widgetslistaddwidgets) to do so. This is exactly how we made the [Visitor Profile](https://matomo.org/docs/user-profile/) available in the dashboard.*
+*Note: Any controller method can be embedded in the dashboard, not just reports. So if you have a popup that you'd like to make available as a dashboard widget, you can create a widget class for it. This is exactly how we made the [Visitor Profile](https://matomo.org/docs/user-profile/) available in the dashboard.*
 
 ## Core report visualizations
 

--- a/docs/5.x/visualizing-report-data.md
+++ b/docs/5.x/visualizing-report-data.md
@@ -263,15 +263,13 @@ Report data can also be manipulated by setting the [`$filters`](/api-reference/P
 
 #### Making your visualization available everywhere
 
-If you want to allow Piwik users to use your visualization on any report (by clicking the appropriate footer icon), add it to the global list of available visualizations in the [`ViewDataTable.addViewDataTable`](/api-reference/events#viewdatatableaddviewdatatable) event:
+If you want to allow Piwik users to use your visualization on any report (by clicking the appropriate footer icon), place your visualization class in the `Visualizations/` directory of your plugin:
 
-```php
-// event handler for ViewDataTable.addViewDataTable in MyPlugin plugin
-public function addViewDataTable(&$visualizations)
-{
-    $visualizations[] = 'Piwik\Plugins\MyPlugin\Visualizations\MyVisualization';
-}
 ```
+plugins/MyPlugin/Visualizations/MyVisualization.php
+```
+
+Visualizations in this directory are automatically discovered by Matomo and added to the global list of available visualizations. No event subscription is needed.
 
 Visualizations that are exposed this way must have the `FOOTER_ICON` and `FOOTER_ICON_TITLE` [ViewDataTable metadata](#viewdatatable-metadata) set.
 

--- a/docs/5.x/visualizing-report-data.md
+++ b/docs/5.x/visualizing-report-data.md
@@ -231,7 +231,7 @@ class MyVisualization extends Visualization
         $date = Common::getRequestVar('date');
         $yesterday = Date::factory($date)->subDay(1)->toString();
 
-        $this->config->request_parameters_to_modify['date'] = $yesterday;
+        $this->requestConfig->request_parameters_to_modify['date'] = $yesterday;
     }
 }
 ```


### PR DESCRIPTION
## Summary
Replace deprecated ViewDataTable.addViewDataTable event with auto-discovery mechanism, replace outdated WidgetsList::add() with modern widget API, and fix incorrect config object reference.

## Changes
- docs(visualizing-report-data): replace deprecated ViewDataTable.addViewDataTable event with auto-discovery
- docs(visualizing-report-data): replace outdated WidgetsList::add() with modern widget API
- docs(visualizing-report-data): fix incorrect config object for request_parameters_to_modify

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules