### PR TITLE
Fix WordPress docs: correct API examples and code errors

### DIFF
--- a/docs/5.x/wordpress/basics.md
+++ b/docs/5.x/wordpress/basics.md
@@ -49,7 +49,7 @@ Example:
 \WpMatomo\Admin\Menu::get_matomo_reporting_url( $category = 'General_Visitors', $subcategory = 'General_Overview', $additional_url_params = array() );
 // This will generate a link like this:
 // https://example.com/wp-content/plugins/matomo/app/index.php?module=CoreHome&action=index&idSite=1&period=day&date=yesterday#?idSite=1&period=day&date=yesterday&category=General_Visitors&subcategory=General_Overview
-// You can add additional url parameters if needed, for example array('idGoal' = 1)
+// You can add additional url parameters if needed, for example array('idGoal' => 1)
 ```
 
 The above example would send a user right to the Visitors => Overview reporting page.
@@ -62,7 +62,7 @@ Example:
 \WpMatomo\Admin\Menu::get_matomo_action_url( $module = 'PrivacyManager', $action = 'privacySettings', $additional_url_params = array() );
 // This will generate a link like this:
 // https://example.com/wp-content/plugins/matomo/app/index.php?module=PrivacyManager&action=privacySettings&idSite=1&period=day&date=yesterday
-// You can add additional url parameters if needed, for example array('idGoal' = 1)
+// You can add additional url parameters if needed, for example array('idGoal' => 1)
 ```
 
 This link will show a specific controller action that is defined in a Matomo plugin.

--- a/docs/5.x/wordpress/classes-reference.md
+++ b/docs/5.x/wordpress/classes-reference.md
@@ -31,7 +31,7 @@ This is the API Reference for developers who want to enrich the [Matomo for Word
 Example:
 
 ```php
-if (current_user_can(\WpMatomo\Capabilities::KEY_SUPERUSER) {
+if (current_user_can(\WpMatomo\Capabilities::KEY_SUPERUSER)) {
     // user has super user permission
 }
 ```

--- a/docs/5.x/wordpress/hooks-reference.md
+++ b/docs/5.x/wordpress/hooks-reference.md
@@ -56,7 +56,7 @@ If WP MultiSites is used, this action is executed after a particular blog was un
 
 This action is executed each time a specific site in Matomo was synced / updated.
 
-* `matomo_ecommerce_init ( \PiwikTracker $tracker )`
+* `matomo_ecommerce_init ( \MatomoTracker $tracker )`
 
 This action can be used to register support for additional ecommerce stores. The hook is triggered on plugin load if the user has ecommerce and tracking enabled. An instance of the [Matomo Tracker](https://github.com/matomo-org/matomo-php-tracker) is passed and can be used to track purchases etc server side if needed (eg during an ajax request). 
 

--- a/docs/5.x/wordpress/matomo-plugin.md
+++ b/docs/5.x/wordpress/matomo-plugin.md
@@ -72,7 +72,7 @@ Now you can for example add below code to hook into WordPress and it will only b
 ```php
 if (defined( 'ABSPATH') && function_exists('add_action')) {
     // the Matomo plugin is used within wordpress...
-    apply_filters('post_row_actions', function ($actions, $post) {
+    add_filter('post_row_actions', function ($actions, $post) {
         $actions['link_to_my_plugin'] = '<a target="_blank" href="'.\WpMatomo\Admin\Menu::make_matomo_action_link('MyPlugin', 'index').'">View My Matomo Plugin</a>';
         return $actions;
     }, 10, 2);

--- a/docs/5.x/wordpress/restapi-reference.md
+++ b/docs/5.x/wordpress/restapi-reference.md
@@ -10,7 +10,7 @@ For more details about each method and all the available parameters please view 
 
 Example endpoint: https://example.com/index.php?rest_route=/matomo/v1
 
-Example request: https://example.com/index.php?rest_route=/matomo/v1/api/processed_report&period=date&date=year&filter_limit=10&apiModule=Actions&apiActions=getPageUrls
+Example request: https://example.com/index.php?rest_route=/matomo/v1/api/processed_report&period=date&date=year&filter_limit=10&apiModule=Actions&apiAction=getPageUrls
 
 Namespace: `matomo/v1`
 


### PR DESCRIPTION
## Summary
Fix multiple code errors in WordPress integration documentation including wrong API action name, deprecated PiwikTracker class reference, missing syntax in array examples, unclosed parenthesis, and incorrect filter function.

## Changes
- docs(restapi-reference): fix apiActions to apiAction in example URL
- docs(hooks-reference): replace deprecated PiwikTracker with MatomoTracker
- docs(basics): fix missing > in fat arrow operator for array examples
- docs(classes-reference): add missing closing parenthesis in if statement
- docs(matomo-plugin): fix apply_filters to add_filter in Example 1

## Review Notes
- All changes verified against the Matomo codebase
- Piwik namespace references in code blocks intentionally preserved
- Reviewed in 3 independent review passes

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules