### PR TITLE
Fix theme.less path in APIs documentation

### DIFF
--- a/docs/5.x/apis.md
+++ b/docs/5.x/apis.md
@@ -26,7 +26,7 @@ Everything below is what we consider API.
 -   JavaScript variables in global `piwik.*` object
     -   as [documented here](https://developer.matomo.org/guides/working-with-piwiks-ui#global-variables-defined-by-piwik)
 -   LESS variables used for Theming
-    -   when [writing a theme for Matomo](/guides/theming) we announce that LESS variables in ([theme.less](https://github.com/matomo-org/matomo/blob/5.x-dev/plugins/Morpheus/stylesheets/theme.less) and [theme-advanced.less](https://github.com/matomo-org/matomo/blob/5.x-dev/plugins/Morpheus/stylesheets/theme-advanced.less)) are API
+    -   when [writing a theme for Matomo](/guides/theming) we announce that LESS variables in [theme.less](https://github.com/matomo-org/matomo/blob/5.x-dev/plugins/ExampleTheme/stylesheets/theme.less) are API
 -   INI Config settings names in `config/global.ini.php` are API
     -   we should not rename INI config settings as users may have overridden them in `config/config.ini.php`
 -   Widgets embed URLs are API


### PR DESCRIPTION
## Summary
- Fix `theme.less` GitHub link from `plugins/Morpheus/stylesheets/` to `plugins/ExampleTheme/stylesheets/`
- Remove stale `theme-advanced.less` reference (file no longer exists in the codebase)

## Changes
- 40c8e554 Fix theme.less path and remove stale theme-advanced.less reference

## Review Notes
- Verified against the Matomo codebase
- Reviewed in documentation audit

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules