### PR TITLE
Fix Vue component path in Matomo 4 to 5 migration guide

### DIFF
--- a/docs/migrate-matomo-4-to-5.md
+++ b/docs/migrate-matomo-4-to-5.md
@@ -43,7 +43,7 @@ A new VueJS component can be created for your plugin using the console command:
 ./console generate:vue-component --pluginname=MYPLUGIN --component=NEWCOMPONENT
 ``` 
 
-This will create an example component in `plugins/MYPLUGIN/vue/src/NEWCOMPONENT.vue` which shows the basic component structure and can be used as a starting point to build a new component.
+This will create an example component in `plugins/MYPLUGIN/vue/src/NEWCOMPONENT/NEWCOMPONENT.vue` which shows the basic component structure and can be used as a starting point to build a new component.
 
 Because Matomo uses [TypeScript](https://www.typescriptlang.org/) within its VueJS components, the `*.vue` files will be compiled and stored in `/plugins/MYPLUGIN/vue/dist` before they can be used. This can be achieved using the following console command:
 


### PR DESCRIPTION
## Summary
- Fix generated Vue component path from `vue/src/NEWCOMPONENT.vue` to `vue/src/NEWCOMPONENT/NEWCOMPONENT.vue`

## Changes
- 68b3a2e6 Fix Vue component path in Matomo 4 to 5 migration guide

## Review Notes
- Verified against the Matomo codebase (`plugins/CoreVue/Commands/GenerateVueComponent.php`)
- Reviewed in documentation audit

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules