### PR TITLE
Fix maxPointColor typo in theming docs

### DIFF
--- a/docs/5.x/theming.md
+++ b/docs/5.x/theming.md
@@ -145,7 +145,7 @@ Here is a list of all named colors in Matomo:
   * **lineColor**: The color of the line in the sparkline.
   * **minPointColor**: The color of the point that marks the minimum value observed in the data set.
   * **lastPointColor**: The color of the point that marks the last value of the data set.
-  * **maxPointColo**: The color of the point that marks the maximum value observed in the data set.
+  * **maxPointColor**: The color of the point that marks the maximum value observed in the data set.
 
 * _Namespace_: **bar-graph-colors**: contains colors for bar graph [report visualizations](/guides/visualizing-report-data).
 


### PR DESCRIPTION
## Summary
- Fix `maxPointColo` to `maxPointColor` (missing trailing 'r')

## Changes
- 84cafab3 Fix maxPointColo typo to maxPointColor in theming docs

## Review Notes
- Verified against the Matomo codebase
- Reviewed in documentation audit

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules