### PR TITLE
Fix doBootstrap() typo in WordPress classes reference

### DIFF
--- a/docs/5.x/wordpress/classes-reference.md
+++ b/docs/5.x/wordpress/classes-reference.md
@@ -11,7 +11,7 @@ This is the API Reference for developers who want to enrich the [Matomo for Word
 
 ## `\WpMatomo\Bootstrap`
 
-* `::doBootstap()` - Lets you bootstrap Matomo application within WordPress. Once Matomo is bootstrapped, you can access all [Matomo PHP API's](https://developer.matomo.org/api-reference/classes).
+* `::doBootstrap()` - Lets you bootstrap Matomo application within WordPress. Once Matomo is bootstrapped, you can access all [Matomo PHP API's](https://developer.matomo.org/api-reference/classes).
 
 ## `\WpMatomo\Site`
 


### PR DESCRIPTION
## Summary
- Fix `doBootstap()` to `doBootstrap()` (missing 'r')

## Changes
- ab71f655 Fix doBootstap() typo to doBootstrap() in WordPress classes reference

## Review Notes
- Verified against the Matomo codebase
- Reviewed in documentation audit

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules