### PR TITLE
Remove duplicate endpoint in Marketplace HTTP API docs

### DIFF
--- a/docs/marketplace-http-api.md
+++ b/docs/marketplace-http-api.md
@@ -34,7 +34,6 @@ This is only needed for accessing purchased premium features.
 * https://plugins.matomo.org/api/1.0/plugins/checkUpdates
 * https://plugins.matomo.org/api/1.0/plugins/:pluginname/info
 * https://plugins.matomo.org/api/1.0/plugins/:pluginname/download/:pluginversion
-* https://plugins.matomo.org/api/1.0/plugins/:pluginname/download/:pluginversion
 * https://plugins.matomo.org/api/1.0/(developer|artist)/:owner
 
 ### From Version 2


### PR DESCRIPTION
## Summary
- Remove duplicate `plugins/:pluginname/download/:pluginversion` endpoint entry

## Changes
- 06f6a85e Remove duplicate endpoint entry in Marketplace HTTP API docs

## Review Notes
- Verified against the Matomo codebase
- Reviewed in documentation audit

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules