### PR TITLE
Fix Draft PR location description for consistency

### DIFF
--- a/docs/pull-request-reviews.md
+++ b/docs/pull-request-reviews.md
@@ -9,7 +9,7 @@ To [contribute code to Matomo](/guides/contributing-to-piwik-core) you will need
 
 This is the overall process for getting a PR merged from PR creation to merging a PR. For more details read the entire page.
 
-* When creating a PR and you're still working on it, it is recommended to mark your PR as `Draft` (you can do this in the `Reviewers` section). Once the PR is done and ready for a review click on `Ready for review` and add the label `Needs Review`. If a PR references another issue we assign the label `not-in-changelog`. The PR author also assigns the PR to a milestone (usually the same milestone as the referenced issue).
+* When creating a PR and you're still working on it, it is recommended to mark your PR as `Draft` (you can do this via the `Convert to draft` link in the GitHub PR sidebar). Once the PR is done and ready for a review click on `Ready for review` and add the label `Needs Review`. If a PR references another issue we assign the label `not-in-changelog`. The PR author also assigns the PR to a milestone (usually the same milestone as the referenced issue).
 * The reviewer selects "Approve / Reject changes / Comment" when finishing a review so it's clear if a PR is accepted or more changes are needed.
 * The PR author marks an individual review conversation/comment as resolved when the feedback was applied or notices/acknowledged (not always do need changes to be made for each comment as sometimes they are suggestions etc).
   * If further feedback is needed for the conversation/comment then PR author will ask the reviewer to confirm the conversation is resolved.


### PR DESCRIPTION
## Summary
- Fix line 12 to correctly describe the Draft PR location as the GitHub PR sidebar (via `Convert to draft` link), consistent with the description on line 36

## Changes
- 87008c11 Fix Draft PR location description for consistency

## Review Notes
- Verified against the Matomo codebase
- Reviewed in documentation audit

Generated with [Claude Code](https://claude.ai/claude-code)

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules