### PR TITLE
No longer caching demo responses, PG-5179

### DIFF
--- a/app/helpers/CacheMiddleware.php
+++ b/app/helpers/CacheMiddleware.php
@@ -82,7 +82,11 @@ class CacheMiddleware
 
     private function shouldCache(Request $req)
     {
-        return $req->getMethod() == "GET";
+        if ($req->getMethod() !== "GET") {
+            return false;
+        }
+
+        return strpos($req->getUri()->getPath(), '/demo/') !== 0;
     }
 
     private function getCacheKey(Request $req)


### PR DESCRIPTION
### Description

Cache middleware was also including API responses because of our proxy. No longer caching any GET requests to `/demo/...`

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
