### PR TITLE
Remove response caching for demo proxy, #PG-5179

### DIFF
--- a/app/routes/page.php
+++ b/app/routes/page.php
@@ -284,7 +284,10 @@ $app->get('/demo/{path:.*}', function (Request $request, Response $response, $ar
     }
 
     $response->getBody()->write($proxiedResponse['body']);
-    return $response->withStatus($proxiedResponse['statusCode']);
+    return $response->withHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
+        ->withHeader('Pragma', 'no-cache')
+        ->withHeader('Expires', '0')
+        ->withStatus($proxiedResponse['statusCode']);
 });
 
 $app->post('/receive-commit-hook', function (Request $request, Response $response, $args) {

--- a/app/routes/page.php
+++ b/app/routes/page.php
@@ -273,14 +273,20 @@ $app->get('/demo/{path:.*}', function (Request $request, Response $response, $ar
         $targetUrl = DemoProxy::buildValidatedApiUrl($path, $request->getQueryParams());
     } catch (\InvalidArgumentException $e) {
         $response->getBody()->write($e->getMessage());
-        return $response->withStatus(400);
+        return $response->withHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
+            ->withHeader('Pragma', 'no-cache')
+            ->withHeader('Expires', '0')
+            ->withStatus(400);
     }
 
     try {
         $proxiedResponse = DemoProxy::get($targetUrl);
     } catch (\RuntimeException $e) {
         $response->getBody()->write('Could not proxy demo request');
-        return $response->withStatus(502);
+        return $response->withHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
+            ->withHeader('Pragma', 'no-cache')
+            ->withHeader('Expires', '0')
+            ->withStatus(502);
     }
 
     $response->getBody()->write($proxiedResponse['body']);


### PR DESCRIPTION
### Description

Getting a response like this on developer docs, going to try to stop downstream caching
```
 <?xml version="1.0" encoding="utf-8" ?>
  <result>5.11.0-alpha.20260505013816</result>
  <!-- Cached response -->
  Response headers
   alt-svc: h3=":443"; ma=86400
   cache-control: max-age=691200
   content-encoding: br
   content-type: text/html; charset=UTF-8
   date: Thu,07 May 2026 21:16:05 GMT
   expires: Fri,15 May 2026 21:16:05 GMT
   server: Apache
   strict-transport-security: max-age=63072000;
   vary: X-matomo-key,Accept-Encoding
   via: 1.1 alproxy,1.1 8c9b9ae51678facd29a99f65367deca2.cloudfront.net (CloudFront)
   x-amz-cf-id: Ofqn_6vYluRnZctfEJwRf_VadcmZxw8jw28TpumH_oPc_imjhY-Ufg==
   x-amz-cf-pop: AKL53-P2
   x-cache: Miss from cloudfront
   x-content-type-options: nosniff
   x-edge-internal-latency-nonoverhead: 1102
   x-xss-protection: 0

```

### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
