### PR TITLE
Added CPO suggestion for plugin list & footnote with links to old documentation #PG-5194 & #PG-5185

### DIFF
--- a/app/helpers/OpenApiSpecRegistry.php
+++ b/app/helpers/OpenApiSpecRegistry.php
@@ -7,6 +7,7 @@ namespace helpers;
  */
 class OpenApiSpecRegistry
 {
+
     /**
      * @return string
      */
@@ -16,7 +17,15 @@ class OpenApiSpecRegistry
     }
 
     /**
-     * @return array<int, array{name: string, slug: string, file: string, url: string}>
+     * @return string
+     */
+    public static function getPluginMetadataPath()
+    {
+        return self::getOpenApiDirectory() . '/plugin_metadata_v1.0.0.json';
+    }
+
+    /**
+     * @return array<int, array{name: string, slug: string, file: string, url: string, summary: string}>
      */
     public static function getPluginSpecs()
     {
@@ -25,6 +34,7 @@ class OpenApiSpecRegistry
             return [];
         }
 
+        $pluginMetadata = self::getPluginMetadata();
         $specs = [];
         foreach ($files as $file) {
             $basename = basename($file);
@@ -43,6 +53,7 @@ class OpenApiSpecRegistry
                 'slug' => self::toSlug($name),
                 'file' => $basename,
                 'url' => '/openapi/' . $basename,
+                'summary' => self::getPluginSummary($pluginMetadata, $name),
             ];
         }
 
@@ -55,7 +66,7 @@ class OpenApiSpecRegistry
 
     /**
      * @param string $slug
-     * @return array{name: string, slug: string, file: string, url: string}|null
+     * @return array{name: string, slug: string, file: string, url: string, summary: string}|null
      */
     public static function getPluginSpecBySlug($slug)
     {
@@ -70,7 +81,7 @@ class OpenApiSpecRegistry
 
     /**
      * @param string $slug
-     * @return array{pluginSpec: array{name: string, slug: string, file: string, url: string}, pluginSpecData: array<mixed>}|null
+     * @return array{pluginSpec: array{name: string, slug: string, file: string, url: string, summary: string}, pluginSpecData: array<mixed>}|null
      */
     public static function getPluginSpecDocumentBySlug($slug)
     {
@@ -127,5 +138,34 @@ class OpenApiSpecRegistry
             ' ',
             $value
         ));
+    }
+
+    /**
+     * @return array<string, array{description?: mixed}>
+     */
+    private static function getPluginMetadata(): array
+    {
+        $metadataContents = @file_get_contents(self::getPluginMetadataPath());
+        if ($metadataContents === false) {
+            return [];
+        }
+
+        $metadata = json_decode($metadataContents, true);
+
+        return is_array($metadata) ? $metadata : [];
+    }
+
+    /**
+     * @param array<string, array{description?: mixed}> $metadataByPlugin
+     */
+    private static function getPluginSummary(array $metadataByPlugin, string $pluginName): string
+    {
+        $summary = $metadataByPlugin[$pluginName]['description'] ?? '';
+
+        if (is_string($summary)) {
+            return trim($summary);
+        }
+
+        return '';
     }
 }

--- a/app/public/css/documentation.css
+++ b/app/public/css/documentation.css
@@ -74,17 +74,48 @@
     background: white;
 }
 
-.documentation #api-docs-list {
-    columns: 3;
-    column-gap: 24px;
-    list-style-type: none;
-    padding: 0;
-    margin: 0;
+.documentation .api-docs-summary-list {
+    margin-top: 24px;
+    padding-left: 24px;
 }
 
-.documentation #api-docs-list li {
-    break-inside: avoid;
-    margin-bottom: 8px;
+.documentation .api-docs-summary-row {
+    display: list-item;
+    margin-bottom: 10px;
+    line-height: 1.3;
+}
+
+.documentation .api-docs-summary-content {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+}
+
+.documentation .api-docs-summary-name {
+    font-size: 15px;
+}
+
+.documentation .api-docs-summary-separator {
+    color: #337ab7;
+    margin-left: 0;
+    font-size: 15px;
+}
+
+.documentation .api-docs-summary-description {
+    display: inline;
+    font-size: 15px;
+}
+
+@media (max-width: 767px) {
+    .documentation .api-docs-summary-name {
+        font-size: 16px;
+    }
+}
+
+
+.old-api-docs-paragraph {
+    display: block !important;
 }
 
 .documentation .collapsed {
@@ -134,16 +165,4 @@
 
 .documentation.api-swagger-index-collapsible-ready .api-swagger-index-collapsed {
     display: none;
-}
-
-@media (max-width: 991px) {
-    .documentation #api-docs-list {
-        columns: 2;
-    }
-}
-
-@media (max-width: 767px) {
-    .documentation #api-docs-list {
-        columns: 1;
-    }
 }

--- a/app/templates/api-swagger-index.twig
+++ b/app/templates/api-swagger-index.twig
@@ -6,13 +6,17 @@
     {% if pluginSpecs is empty %}
         <p>No API modules are currently available.</p>
     {% else %}
-        <ul id="api-docs-list">
+        <ul class="api-docs-summary-list" id="api-docs-summary-list">
             {% for pluginSpec in pluginSpecs %}
-                <li>
-                    <a href="{{ ('/api-reference/api/' ~ pluginSpec.slug)|completeUrl }}">{{ pluginSpec.name }}</a>
+                <li class="api-docs-summary-row">
+                    <span class="api-docs-summary-content">
+                        <span class="api-docs-summary-name"><a href="{{ ('/api-reference/api/' ~ pluginSpec.slug)|completeUrl }}">{{ pluginSpec.name }}</a><span class="api-docs-summary-separator">:</span></span>
+                        <span class="api-docs-summary-description">{{ pluginSpec.summary }}</span>
+                    </span>
                 </li>
             {% endfor %}
         </ul>
+        <p class="old-api-docs-paragraph">Looking for the legacy API reference? The <a href="https://developer.matomo.org/api-reference/reporting-api">legacy API reference</a> page is still available while we continue improving the new API documentation. If anything is missing or behaving unexpectedly in this new version, <a href="https://matomo.org/support/">please let us know</a> so we can improve the experience.</p>
     {% endif %}
 {% endblock %}
 

--- a/app/templates/api-swagger-index.twig
+++ b/app/templates/api-swagger-index.twig
@@ -10,8 +10,8 @@
             {% for pluginSpec in pluginSpecs %}
                 <li class="api-docs-summary-row">
                     <span class="api-docs-summary-content">
-                        <span class="api-docs-summary-name"><a href="{{ ('/api-reference/api/' ~ pluginSpec.slug)|completeUrl }}">{{ pluginSpec.name }}</a><span class="api-docs-summary-separator">:</span></span>
-                        <span class="api-docs-summary-description">{{ pluginSpec.summary }}</span>
+                        <span class="api-docs-summary-name"><a href="{{ ('/api-reference/api/' ~ pluginSpec.slug)|completeUrl }}">{{ pluginSpec.name }}</a>{% if pluginSpec.summary is not empty %}<span class="api-docs-summary-separator">:</span>{% endif %}</span>
+                        {% if pluginSpec.summary is not empty %}<span class="api-docs-summary-description">{{ pluginSpec.summary }}</span>{% endif %}
                     </span>
                 </li>
             {% endfor %}

--- a/app/templates/api-swagger-index.twig
+++ b/app/templates/api-swagger-index.twig
@@ -67,7 +67,7 @@
 
             function shouldStartCollapsed(section) {
                 return !section.elements.some(function (element) {
-                    return element.id === 'api-docs-list';
+                    return element.id === 'api-docs-summary-list';
                 });
             }
 

--- a/app/templates/api-swagger-index.twig
+++ b/app/templates/api-swagger-index.twig
@@ -16,7 +16,7 @@
                 </li>
             {% endfor %}
         </ul>
-        <p class="old-api-docs-paragraph">Looking for the legacy API reference? The <a href="https://developer.matomo.org/api-reference/reporting-api">legacy API reference</a> page is still available while we continue improving the new API documentation. If anything is missing or behaving unexpectedly in this new version, <a href="https://matomo.org/support/">please let us know</a> so we can improve the experience.</p>
+        <p class="old-api-docs-paragraph">Looking for the legacy API reference? The <a href="/api-reference/reporting-api">legacy API reference</a> page is still available while we continue improving the new API documentation. If anything is missing or behaving unexpectedly in this new version, <a href="https://matomo.org/support/">please let us know</a> so we can improve the experience.</p>
     {% endif %}
 {% endblock %}
 

--- a/fetch-openapi-specs.php
+++ b/fetch-openapi-specs.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 $baseUrl = rtrim(getenv('MATOMO_BASE_URL') ?: 'https://demo.matomo.cloud/', '/');
 $tokenAuth = getenv('MATOMO_TOKEN_AUTH') ?: 'anonymous';
 $targetDirectory = __DIR__ . '/app/public/openapi';
+$metadataPath = $targetDirectory . '/plugin_metadata_v1.0.0.json';
 $version = '1.0.0';
 $excludedPlugins = [
     'LogViewer',
@@ -70,6 +71,31 @@ function getSpecPath(string $targetDirectory, string $plugin, string $version): 
     return sprintf('%s/%s_openapi_spec_v%s.json', $targetDirectory, $plugin, $version);
 }
 
+function writeJsonFile(string $path, array $data, string $errorContext): void
+{
+    $json = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    if ($json === false) {
+        throw new RuntimeException("Failed to encode JSON for $errorContext");
+    }
+
+    $json .= "\n";
+    $directory = dirname($path);
+    $tempPath = tempnam($directory, 'openapi_');
+    if ($tempPath === false) {
+        throw new RuntimeException("Failed to create temporary file for $errorContext");
+    }
+
+    if (file_put_contents($tempPath, $json) === false) {
+        @unlink($tempPath);
+        throw new RuntimeException("Failed to write file: $path");
+    }
+
+    if (!rename($tempPath, $path)) {
+        @unlink($tempPath);
+        throw new RuntimeException("Failed to move temporary file into place: $path");
+    }
+}
+
 function fetchJson(string $baseUrl, string $tokenAuth, array $params): array
 {
     $params['module'] = 'API';
@@ -119,10 +145,19 @@ function fetchJson(string $baseUrl, string $tokenAuth, array $params): array
 
 try {
     $plugins = fetchJson($baseUrl, $tokenAuth, [
-        'method' => 'OpenApiDocs.getPluginWhitelist',
+        'method' => 'OpenApiDocs.getAllowedPlugins',
     ]);
 } catch (Throwable $e) {
     fwrite(STDERR, "Failed to fetch plugin whitelist: {$e->getMessage()}\n");
+    exit(1);
+}
+
+try {
+    $pluginMetadata = fetchJson($baseUrl, $tokenAuth, [
+        'method' => 'OpenApiDocs.getAllowedPluginMetadata',
+    ]);
+} catch (Throwable $e) {
+    fwrite(STDERR, "Failed to fetch plugin metadata: {$e->getMessage()}\n");
     exit(1);
 }
 
@@ -152,26 +187,7 @@ foreach ($plugins as $plugin) {
 
         $path = getSpecPath($targetDirectory, $plugin, $version);
         $expectedPaths[] = $path;
-        $json = json_encode($spec, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-        if ($json === false) {
-            throw new RuntimeException("Failed to encode JSON for plugin $plugin");
-        }
-
-        $json .= "\n";
-        $tempPath = tempnam($targetDirectory, $plugin . '_openapi_');
-        if ($tempPath === false) {
-            throw new RuntimeException("Failed to create temporary file for plugin $plugin");
-        }
-
-        if (file_put_contents($tempPath, $json) === false) {
-            @unlink($tempPath);
-            throw new RuntimeException("Failed to write file: $path");
-        }
-
-        if (!rename($tempPath, $path)) {
-            @unlink($tempPath);
-            throw new RuntimeException("Failed to move temporary file into place: $path");
-        }
+        writeJsonFile($path, $spec, "plugin $plugin");
 
         $written++;
     } catch (Throwable $e) {
@@ -184,6 +200,13 @@ try {
     removeStaleSpecFiles($targetDirectory, $expectedPaths);
 } catch (Throwable $e) {
     fwrite(STDERR, "Failed to clean up stale spec files: {$e->getMessage()}\n");
+    exit(1);
+}
+
+try {
+    writeJsonFile($metadataPath, $pluginMetadata, 'plugin metadata');
+} catch (Throwable $e) {
+    fwrite(STDERR, "Failed to write plugin metadata: {$e->getMessage()}\n");
     exit(1);
 }
 


### PR DESCRIPTION


### Description

fetch-openapi-specs.php will now also fetch and store metadata about our plugins that we can use. 

Should still work without new endpoint, as the plugin names still use the old endpoint, but descriptions wont be available. 


### Checklist

- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
